### PR TITLE
Add support for GCC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 cmake_minimum_required (VERSION 3.8)
 project (DirectXMath-CMake LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
@@ -16,120 +16,118 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin/CMake")
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin/CMake")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin/CMake")
 
-set(WarningsEXE "-Wall" "-Wpedantic" "-Wextra"
-    "-Wno-c++98-compat" "-Wno-c++98-compat-pedantic"
-    "-Wno-gnu-anonymous-struct" "-Wno-nested-anon-types"
-    "-Wno-float-equal" "-Wno-double-promotion"
-    "-Wno-missing-variable-declarations" "-Wno-missing-prototypes"
-    "-Wno-global-constructors"
-    "-Wno-reserved-id-macro" "-Wno-undef" )
+include_directories(../Inc ../Extensions ../SHMath ../XDSP)
 
+#Optimization flags
+set(ARCH_AVX   $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-mavx> $<$<CXX_COMPILER_ID:MSVC>:/arch:AVX>)
+set(ARCH_AVX2  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-mavx2 -mfma -mf16c> $<$<CXX_COMPILER_ID:MSVC>:/arch:AVX2>)
+set(ARCH_F16C  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-mf16c>)
+set(ARCH_FMA   $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-mfma>)
+set(ARCH_FMA4  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-mfma4>)
+set(ARCH_SSE2  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-msse2> $<$<CXX_COMPILER_ID:MSVC>:/arch:SSE2>)
+set(ARCH_SSE3  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-msse3>)
+set(ARCH_SSSE3 $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-mssse3>)
+
+#compile options
+if(MSVC)
+    add_compile_options("/W3" "/Wall" "/EHsc" "/fp:fast" "/permissive-" "/Zc:__cplusplus" "/wd4514")
+else()
+    add_compile_options(
+        "-Wall" "-Wpedantic" "-Wextra"
+        "-Wno-float-equal" "-Wno-double-promotion" "-Wno-missing-prototypes"
+        "-Wno-undef" "-Wno-unknown-pragmas"
+    )
+endif()
+if ( CMAKE_CXX_COMPILER_ID MATCHES "Clang" )
+    add_compile_options(
+        "-Wno-reserved-id-macro" "-Wno-c++98-compat" "-Wno-c++98-compat-pedantic"
+        "-Wno-gnu-anonymous-struct" "-Wno-global-constructors" "-Wno-missing-variable-declarations"
+        "-Wno-nested-anon-types"
+    )
+endif()
+
+#CPUID
 add_executable(cpuid cpuid/cpuid.cpp)
+target_compile_options(cpuid PRIVATE ${ARCH_AVX})
 
-add_executable(math3
-math3/box.cpp
-math3/constexpr.cpp
-math3/frustum.cpp
-math3/math3.cpp
-math3/math3tests.cpp
-math3/obox.cpp
-math3/shared.cpp
-math3/sphere.cpp
-math3/triangle.cpp
-math3/xmcolor.cpp
-math3/xmmat.cpp
-math3/xmquat.cpp
-math3/xmvec.cpp
-math3/xmvec234.cpp)
+#MATH3
+set(MATH3_SRCS
+    math3/box.cpp
+    math3/constexpr.cpp
+    math3/frustum.cpp
+    math3/math3.cpp
+    math3/math3tests.cpp
+    math3/obox.cpp
+    math3/shared.cpp
+    math3/sphere.cpp
+    math3/triangle.cpp
+    math3/xmcolor.cpp
+    math3/xmmat.cpp
+    math3/xmquat.cpp
+    math3/xmvec.cpp
+    math3/xmvec234.cpp
+)
 
+add_executable(math3_sse2 ${MATH3_SRCS})
+target_compile_options(math3_sse2 PRIVATE ${ARCH_SSE2})
+
+add_executable(math3_avx ${MATH3_SRCS})
+target_compile_options(math3_avx PRIVATE ${ARCH_AVX})
+
+add_executable(math3_avx2 ${MATH3_SRCS})
+target_compile_options(math3_avx2 PRIVATE ${ARCH_AVX2})
+
+#SHMath
 add_executable(shmathtest
-shmath/test.cpp
-shmath/DDSTextureLoader.cpp
-shmath/DDSTextureLoader.h
-shmath/DDSTextureLoader12.cpp
-shmath/DDSTextureLoader12.h
-../SHMath/DirectXSH.cpp
-../SHMath/DirectXSH.h
-../SHMath/DirectXSHD3D11.cpp
-../SHMath/DirectXSHD3D12.cpp)
+    shmath/test.cpp
+    ../SHMath/DirectXSH.cpp
+    ../SHMath/DirectXSH.h
+)
+if(WIN32)
+    target_sources(shmathtest PRIVATE
+        shmath/DDSTextureLoader.cpp
+        shmath/DDSTextureLoader.h
+        shmath/DDSTextureLoader12.cpp
+        shmath/DDSTextureLoader12.h
+        ../SHMath/DirectXSHD3D11.cpp
+        ../SHMath/DirectXSHD3D12.cpp
+    )
+    target_compile_definitions(shmathtest PRIVATE USE_DIRECT3D12=1 )
+    target_link_libraries(shmathtest d3d11.lib dxgi.lib d3d12.lib dxguid.lib )
+endif()
 
-add_executable(testavx ext/testavx.cpp)
-add_executable(testavx2 ext/testavx2.cpp)
-add_executable(testbe ext/testbe.cpp)
-add_executable(testf16c ext/testf16c.cpp)
-add_executable(testfma3 ext/testfma3.cpp)
-add_executable(testfma4 ext/testfma4.cpp)
-add_executable(testsse3 ext/testsse3.cpp)
-add_executable(testsse4 ext/testsse4.cpp)
-
+#XDSP
 add_executable(xdsptest xdsp/Test.cpp)
+target_compile_options(xdsptest PRIVATE ${ARCH_AVX2})
 
+#EXT
+add_executable(testavx ext/testavx.cpp)
+target_compile_options(testavx PRIVATE ${ARCH_AVX})
+
+add_executable(testavx2 ext/testavx2.cpp)
+target_compile_options(testavx2 PRIVATE ${ARCH_AVX2})
+
+add_executable(testbe ext/testbe.cpp)
+target_compile_options(testbe PRIVATE ${ARCH_SSSE3})
+
+add_executable(testf16c ext/testf16c.cpp)
+target_compile_options(testf16c PRIVATE ${ARCH_F16C})
+
+add_executable(testfma3 ext/testfma3.cpp)
+target_compile_options(testfma3 PRIVATE ${ARCH_FMA})
+
+add_executable(testfma4 ext/testfma4.cpp)
+target_compile_options(testfma4 PRIVATE ${ARCH_FMA4})
+
+add_executable(testsse3 ext/testsse3.cpp)
+target_compile_options(testsse3 PRIVATE ${ARCH_SSE3})
+
+add_executable(testsse4 ext/testsse4.cpp)
+target_compile_options(testsse4 PRIVATE ${ARCH_SSE4})
+
+#source groups
 source_group(cpuid REGULAR_EXPRESSION cpuid/*.*)
 source_group(Ext REGULAR_EXPRESSION ext/*.*)
 source_group(Math3 REGULAR_EXPRESSION math3/*.*)
 source_group(shmathtest REGULAR_EXPRESSION shmath/*.*)
 source_group(XDSPTest REGULAR_EXPRESSION xdsp/*.*)
-
-target_include_directories( math3 PUBLIC ../inc )
-target_include_directories( shmathtest PUBLIC ../inc ../SHMath )
-target_include_directories( testavx PUBLIC ../inc ../Extensions )
-target_include_directories( testavx2 PUBLIC ../inc ../Extensions )
-target_include_directories( testbe PUBLIC ../inc ../Extensions )
-target_include_directories( testf16c PUBLIC ../inc ../Extensions )
-target_include_directories( testfma3 PUBLIC ../inc ../Extensions )
-target_include_directories( testfma4 PUBLIC ../inc ../Extensions )
-target_include_directories( testsse3 PUBLIC ../inc ../Extensions )
-target_include_directories( testsse4 PUBLIC ../inc ../Extensions )
-target_include_directories( xdsptest PUBLIC ../inc ../XDSP )
-
-target_compile_options( math3 PRIVATE /EHsc /fp:fast )
-target_compile_options( shmathtest PRIVATE /EHsc /fp:fast )
-target_compile_options( testavx PRIVATE /EHsc /fp:fast )
-target_compile_options( testavx2 PRIVATE /EHsc /fp:fast )
-target_compile_options( testbe PRIVATE /EHsc /fp:fast )
-target_compile_options( testf16c PRIVATE /EHsc /fp:fast )
-target_compile_options( testfma3 PRIVATE /EHsc /fp:fast )
-target_compile_options( testfma4 PRIVATE /EHsc /fp:fast )
-target_compile_options( testsse3 PRIVATE /EHsc /fp:fast )
-target_compile_options( testsse4 PRIVATE /EHsc /fp:fast )
-target_compile_options( xdsptest PRIVATE /EHsc /fp:fast )
-
-target_compile_definitions( shmathtest PRIVATE USE_DIRECT3D12=1 )
-
-target_link_libraries( shmathtest d3d11.lib dxgi.lib d3d12.lib dxguid.lib )
-
-if ( CMAKE_CXX_COMPILER_ID MATCHES "Clang" )
-    target_compile_options( cpuid PRIVATE ${WarningsEXE} )
-    target_compile_options( math3 PRIVATE ${WarningsEXE} )
-    target_compile_options( shmathtest PRIVATE ${WarningsEXE} )
-    target_compile_options( testavx PRIVATE ${WarningsEXE} /arch:AVX )
-    target_compile_options( testavx2 PRIVATE ${WarningsEXE} /arch:AVX2 )
-    target_compile_options( testbe PRIVATE ${WarningsEXE} -mssse3 )
-    target_compile_options( testf16c PRIVATE ${WarningsEXE} -mf16c )
-    target_compile_options( testfma3 PRIVATE ${WarningsEXE} /arch:AVX2 )
-    target_compile_options( testfma4 PRIVATE ${WarningsEXE} /arch:AVX -mfma4 )
-    target_compile_options( testsse3 PRIVATE ${WarningsEXE} -msse3 )
-    target_compile_options( testsse4 PRIVATE ${WarningsEXE} )
-    target_compile_options( xdsptest PRIVATE ${WarningsEXE} )
-    if (${CMAKE_SIZEOF_VOID_P} EQUAL "4")
-        target_compile_options( math3 PRIVATE /arch:SSE2 )
-        target_compile_options( shmathtest PRIVATE /arch:SSE2 )
-        target_compile_options( testsse3 PRIVATE /arch:SSE2 )
-        target_compile_options( testsse4 PRIVATE /arch:SSE2 )
-        target_compile_options( xdsptest PRIVATE /arch:SSE2 )
-    endif()
-endif()
-if ( CMAKE_CXX_COMPILER_ID MATCHES "MSVC" )
-    target_compile_options( cpuid PRIVATE /Wall /permissive- /Zc:__cplusplus )
-    target_compile_options( math3 PRIVATE /Wall /permissive- /Zc:__cplusplus )
-    target_compile_options( shmathtest PRIVATE /Wall /permissive- /Zc:__cplusplus )
-    target_compile_options( testavx PRIVATE /Wall /permissive- /Zc:__cplusplus /arch:AVX )
-    target_compile_options( testavx2 PRIVATE /Wall /permissive- /Zc:__cplusplus /arch:AVX2 )
-    target_compile_options( testbe PRIVATE /Wall /permissive- /Zc:__cplusplus )
-    target_compile_options( testf16c PRIVATE /Wall /permissive- /Zc:__cplusplus /arch:AVX )
-    target_compile_options( testfma3 PRIVATE /Wall /permissive- /Zc:__cplusplus /arch:AVX2 )
-    target_compile_options( testfma4 PRIVATE /Wall /permissive- /Zc:__cplusplus /arch:AVX )
-    target_compile_options( testsse3 PRIVATE /Wall /permissive- /Zc:__cplusplus )
-    target_compile_options( testsse4 PRIVATE /Wall /permissive- /Zc:__cplusplus )
-    target_compile_options( xdsptest PRIVATE /Wall /permissive- /Zc:__cplusplus )
-endif()

--- a/cpuid/cpuid.cpp
+++ b/cpuid/cpuid.cpp
@@ -2,24 +2,25 @@
 // Licensed under the MIT License.
 
 #include <stdio.h>
-#include <Windows.h>
-#include <excpt.h>
 #include <stdint.h>
 #include <assert.h>
 
 #include <xmmintrin.h>
 
-#ifdef __clang__
+#ifdef _MSC_VER
+#include <excpt.h>
+#include <intrin.h>
+#else
 #include <cpuid.h>
 #include <x86intrin.h>
-#else
-#include <intrin.h>
 #endif
 
 int main()
 {
 #ifdef __clang__
     printf("cpuid using clang\n");
+#elif __GNUC__
+    printf("cpuid using GCC\n");
 #else
     printf("cpuid using Visual C++\n");
 #endif
@@ -32,18 +33,18 @@ int main()
 
    // See http://msdn.microsoft.com/en-us/library/hskdteyh.aspx
    int CPUInfo[4] = { -1 };
-#ifdef __clang__
-   __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
+#ifdef _MSC_VER
+    __cpuid(CPUInfo, 0); 
 #else
-   __cpuid(CPUInfo, 0);
+   __cpuid(0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #endif
 
    if ( CPUInfo[0] > 0 )
    {
-#ifdef __clang__
-       __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
+#ifdef _MSC_VER
+    __cpuid(CPUInfo, 1);
 #else
-       __cpuid(CPUInfo, 1);
+    __cpuid(1, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);      
 #endif
 
        // EAX
@@ -109,10 +110,10 @@ int main()
 
    if ( CPUInfo[0] >= 7 )
    {
-#ifdef __clang__
-       __cpuid_count(7, 0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
+#ifdef _MSC_VER
+        __cpuidex(CPUInfo, 7, 0);
 #else
-       __cpuidex(CPUInfo, 7, 0);
+       __cpuid_count(7, 0, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #endif
 
        // EBX
@@ -147,18 +148,18 @@ int main()
        printf("CPU doesn't support Structured Extended Feature Flags\n");
 
    // Extended features
-#ifdef __clang__
-   __cpuid(0x80000000, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
+#ifdef _MSC_VER
+    __cpuid(CPUInfo, 0x80000000);
 #else
-   __cpuid(CPUInfo, 0x80000000);
+    __cpuid(0x80000000, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
 #endif
 
    if (uint32_t(CPUInfo[0]) > 0x80000000)
    {
-#ifdef __clang__
-       __cpuid(0x80000001, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
+#ifdef _MSC_VER
+    __cpuid(CPUInfo, 0x80000001);
 #else
-       __cpuid(CPUInfo, 0x80000001);
+    __cpuid(0x80000001, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);    
 #endif
 
        // ECX

--- a/ext/testavx.cpp
+++ b/ext/testavx.cpp
@@ -7,7 +7,6 @@
 // http://go.microsoft.com/fwlink/?LinkID=615560
 //-------------------------------------------------------------------------------------
 
-#include <Windows.h>
 #include <stdio.h>
 
 #include "DirectXMathAVX.h"

--- a/ext/testavx2.cpp
+++ b/ext/testavx2.cpp
@@ -7,7 +7,6 @@
 // http://go.microsoft.com/fwlink/?LinkID=615560
 //-------------------------------------------------------------------------------------
 
-#include <Windows.h>
 #include <stdio.h>
 
 #include "DirectXMathAVX2.h"

--- a/ext/testbe.cpp
+++ b/ext/testbe.cpp
@@ -7,7 +7,6 @@
 // http://go.microsoft.com/fwlink/?LinkID=615560
 //-------------------------------------------------------------------------------------
 
-#include <Windows.h>
 #include <stdio.h>
 
 #include "DirectXMathBE.h"

--- a/ext/testf16c.cpp
+++ b/ext/testf16c.cpp
@@ -7,8 +7,6 @@
 // http://go.microsoft.com/fwlink/?LinkID=615560
 //-------------------------------------------------------------------------------------
 
-#include <Windows.h>
-
 #include <stdio.h>
 
 #include "DirectXMathF16C.h"

--- a/ext/testfma3.cpp
+++ b/ext/testfma3.cpp
@@ -7,7 +7,6 @@
 // http://go.microsoft.com/fwlink/?LinkID=615560
 //-------------------------------------------------------------------------------------
 
-#include <Windows.h>
 #include <stdio.h>
 
 #include "DirectXMathFMA3.h"

--- a/ext/testfma4.cpp
+++ b/ext/testfma4.cpp
@@ -7,7 +7,6 @@
 // http://go.microsoft.com/fwlink/?LinkID=615560
 //-------------------------------------------------------------------------------------
 
-#include <Windows.h>
 #include <stdio.h>
 
 #include "DirectXMathFMA4.h"

--- a/ext/testsse3.cpp
+++ b/ext/testsse3.cpp
@@ -7,7 +7,6 @@
 // http://go.microsoft.com/fwlink/?LinkID=615560
 //-------------------------------------------------------------------------------------
 
-#include <Windows.h>
 #include <stdio.h>
 
 #include "DirectXMathSSE3.h"

--- a/ext/testsse4.cpp
+++ b/ext/testsse4.cpp
@@ -7,7 +7,6 @@
 // http://go.microsoft.com/fwlink/?LinkID=615560
 //-------------------------------------------------------------------------------------
 
-#include <Windows.h>
 #include <stdio.h>
 
 #include "DirectXMathSSE4.h"

--- a/math3/clangcompat.cpp
+++ b/math3/clangcompat.cpp
@@ -17,7 +17,7 @@
 
 #define _XM_NO_XMVECTOR_OVERLOADS_
 
-#include <directxmath.h>
-#include <directxcolors.h>
-#include <directxpackedvector.h>
-#include <directxcollision.h>
+#include <DirectXMath.h>
+#include <DirectXColors.h>
+#include <DirectXPackedVector.h>
+#include <DirectXCollision.h>

--- a/math3/constexpr.cpp
+++ b/math3/constexpr.cpp
@@ -39,100 +39,100 @@ using namespace DirectX::PackedVector;
 
 namespace Test
 {
-    XM_CONSTEXPR float valueRadins = XMConvertToRadians(1.f);
-    XM_CONSTEXPR float valueDegrees = XMConvertToDegrees(XM_PI);
+    constexpr float valueRadins = XMConvertToRadians(1.f);
+    constexpr float valueDegrees = XMConvertToDegrees(XM_PI);
 
-    XM_CONSTEXPR static XMFLOAT2 g_array2[] = { XMFLOAT2(1.f, 2.f), XMFLOAT2(3.f, 4.f) };
-    XM_CONSTEXPR static XMFLOAT2A g_array2a[] = { XMFLOAT2A(1.f, 2.f), XMFLOAT2A(3.f, 4.f) };
+    constexpr static XMFLOAT2 g_array2[] = { XMFLOAT2(1.f, 2.f), XMFLOAT2(3.f, 4.f) };
+    constexpr static XMFLOAT2A g_array2a[] = { XMFLOAT2A(1.f, 2.f), XMFLOAT2A(3.f, 4.f) };
 
-    XM_CONSTEXPR static XMFLOAT3 g_array3[] = { XMFLOAT3(1.f, 2.f, 3.f), XMFLOAT3(4.f, 4.f, 5.f) };
-    XM_CONSTEXPR static XMFLOAT3A g_array3a[] = { XMFLOAT3A(1.f, 2.f, 3.f), XMFLOAT3A(4.f, 4.f, 5.f) };
+    constexpr static XMFLOAT3 g_array3[] = { XMFLOAT3(1.f, 2.f, 3.f), XMFLOAT3(4.f, 4.f, 5.f) };
+    constexpr static XMFLOAT3A g_array3a[] = { XMFLOAT3A(1.f, 2.f, 3.f), XMFLOAT3A(4.f, 4.f, 5.f) };
 
-    XM_CONSTEXPR static XMFLOAT4 g_array4[] = { XMFLOAT4(1.f, 2.f, 3.f, 4.f), XMFLOAT4(5.f, 6.f, 7.f, 8.f) };
-    XM_CONSTEXPR static XMFLOAT4A g_array4a[] = { XMFLOAT4A(1.f, 2.f, 3.f, 4.f), XMFLOAT4A(5.f, 6.f, 7.f, 8.f) };
+    constexpr static XMFLOAT4 g_array4[] = { XMFLOAT4(1.f, 2.f, 3.f, 4.f), XMFLOAT4(5.f, 6.f, 7.f, 8.f) };
+    constexpr static XMFLOAT4A g_array4a[] = { XMFLOAT4A(1.f, 2.f, 3.f, 4.f), XMFLOAT4A(5.f, 6.f, 7.f, 8.f) };
 
-    XM_CONSTEXPR static XMINT2 g_array2i[] = { XMINT2(1, 2), XMINT2(3, 4) };
-    XM_CONSTEXPR static XMUINT2 g_array2u[] = { XMUINT2(1, 2), XMUINT2(3, 4) };
+    constexpr static XMINT2 g_array2i[] = { XMINT2(1, 2), XMINT2(3, 4) };
+    constexpr static XMUINT2 g_array2u[] = { XMUINT2(1, 2), XMUINT2(3, 4) };
 
-    XM_CONSTEXPR static XMINT3 g_array3i[] = { XMINT3(1, 2, 3), XMINT3(4, 5, 6) };
-    XM_CONSTEXPR static XMUINT3 g_array3u[] = { XMUINT3(1, 2, 3), XMUINT3(4, 5, 6) };
+    constexpr static XMINT3 g_array3i[] = { XMINT3(1, 2, 3), XMINT3(4, 5, 6) };
+    constexpr static XMUINT3 g_array3u[] = { XMUINT3(1, 2, 3), XMUINT3(4, 5, 6) };
 
-    XM_CONSTEXPR static XMINT4 g_array4i[] = { XMINT4(1, 2, 3, 4), XMINT4(5, 6, 7, 8) };
-    XM_CONSTEXPR static XMUINT4 g_array4u[] = { XMUINT4(1, 2, 3, 4), XMUINT4(5, 6, 7, 8) };
+    constexpr static XMINT4 g_array4i[] = { XMINT4(1, 2, 3, 4), XMINT4(5, 6, 7, 8) };
+    constexpr static XMUINT4 g_array4u[] = { XMUINT4(1, 2, 3, 4), XMUINT4(5, 6, 7, 8) };
 
-    XM_CONSTEXPR static XMFLOAT3X3 g_array3x3[] = { XMFLOAT3X3(1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f), XMFLOAT3X3(10.f, 11.f, 12.f, 13.f, 14.f, 15.f, 16.f, 17.f, 18.f) };
+    constexpr static XMFLOAT3X3 g_array3x3[] = { XMFLOAT3X3(1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f), XMFLOAT3X3(10.f, 11.f, 12.f, 13.f, 14.f, 15.f, 16.f, 17.f, 18.f) };
     
-    XM_CONSTEXPR static XMFLOAT4X3 g_array4x3[] = { XMFLOAT4X3(1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f), XMFLOAT4X3(13.f, 14.f, 15.f, 16.f, 17.f, 18.f, 19.f, 20.f, 21.f, 22.f, 23.f, 24.f) };
-    XM_CONSTEXPR static XMFLOAT4X3A g_array4x3a[] = { XMFLOAT4X3A(1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f), XMFLOAT4X3A(13.f, 14.f, 15.f, 16.f, 17.f, 18.f, 19.f, 20.f, 21.f, 22.f, 23.f, 24.f) };
+    constexpr static XMFLOAT4X3 g_array4x3[] = { XMFLOAT4X3(1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f), XMFLOAT4X3(13.f, 14.f, 15.f, 16.f, 17.f, 18.f, 19.f, 20.f, 21.f, 22.f, 23.f, 24.f) };
+    constexpr static XMFLOAT4X3A g_array4x3a[] = { XMFLOAT4X3A(1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f), XMFLOAT4X3A(13.f, 14.f, 15.f, 16.f, 17.f, 18.f, 19.f, 20.f, 21.f, 22.f, 23.f, 24.f) };
 
-    XM_CONSTEXPR static XMFLOAT3X4 g_array3x4[] = { XMFLOAT3X4(1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f), XMFLOAT3X4(13.f, 14.f, 15.f, 16.f, 17.f, 18.f, 19.f, 20.f, 21.f, 22.f, 23.f, 24.f) };
-    XM_CONSTEXPR static XMFLOAT3X4A g_array3x4a[] = { XMFLOAT3X4A(1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f), XMFLOAT3X4A(13.f, 14.f, 15.f, 16.f, 17.f, 18.f, 19.f, 20.f, 21.f, 22.f, 23.f, 24.f) };
+    constexpr static XMFLOAT3X4 g_array3x4[] = { XMFLOAT3X4(1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f), XMFLOAT3X4(13.f, 14.f, 15.f, 16.f, 17.f, 18.f, 19.f, 20.f, 21.f, 22.f, 23.f, 24.f) };
+    constexpr static XMFLOAT3X4A g_array3x4a[] = { XMFLOAT3X4A(1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f), XMFLOAT3X4A(13.f, 14.f, 15.f, 16.f, 17.f, 18.f, 19.f, 20.f, 21.f, 22.f, 23.f, 24.f) };
 
-    XM_CONSTEXPR static XMFLOAT4X4 g_array4x4[] = { XMFLOAT4X4(1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f, 13.f, 14.f, 15.f, 16.f), XMFLOAT4X4(17.f, 18.f, 19.f, 20.f, 21.f, 22.f, 23.f, 24.f, 25.f, 26.f, 27.f, 28.f, 29.f, 30.f, 31.f, 32.f) };
-    XM_CONSTEXPR static XMFLOAT4X4A g_array4x4a[] = { XMFLOAT4X4A(1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f, 13.f, 14.f, 15.f, 16.f), XMFLOAT4X4A(17.f, 18.f, 19.f, 20.f, 21.f, 22.f, 23.f, 24.f, 25.f, 26.f, 27.f, 28.f, 29.f, 30.f, 31.f, 32.f) };
+    constexpr static XMFLOAT4X4 g_array4x4[] = { XMFLOAT4X4(1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f, 13.f, 14.f, 15.f, 16.f), XMFLOAT4X4(17.f, 18.f, 19.f, 20.f, 21.f, 22.f, 23.f, 24.f, 25.f, 26.f, 27.f, 28.f, 29.f, 30.f, 31.f, 32.f) };
+    constexpr static XMFLOAT4X4A g_array4x4a[] = { XMFLOAT4X4A(1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f, 13.f, 14.f, 15.f, 16.f), XMFLOAT4X4A(17.f, 18.f, 19.f, 20.f, 21.f, 22.f, 23.f, 24.f, 25.f, 26.f, 27.f, 28.f, 29.f, 30.f, 31.f, 32.f) };
 
     // PackedVector
-    XM_CONSTEXPR static XMCOLOR g_color[] = { 0xff0c0d00, 0x0f0c0b1a };
+    constexpr static XMCOLOR g_color[] = { 0xff0c0d00, 0x0f0c0b1a };
 
-    XM_CONSTEXPR static XMHALF2 g_half2[] = { XMHALF2(HALF(0xabce), HALF(0xabcd)), XMHALF2(HALF(0xabce), HALF(0xabcd)) };
-    XM_CONSTEXPR static XMHALF2 g_half2p[] = { XMHALF2(0xabceabcd) };
+    constexpr static XMHALF2 g_half2[] = { XMHALF2(HALF(0xabce), HALF(0xabcd)), XMHALF2(HALF(0xabce), HALF(0xabcd)) };
+    constexpr static XMHALF2 g_half2p[] = { XMHALF2(0xabceabcd) };
 
-    XM_CONSTEXPR static XMHALF4 g_half4[] = { XMHALF4(HALF(0xabce), HALF(0xabcd), HALF(0xabcd), HALF(0xabcd)), XMHALF4(HALF(0xabce), HALF(0xabcd), HALF(0xabcd), HALF(0xabcd)) };
-    XM_CONSTEXPR static XMHALF4 g_half4p[] = { XMHALF4(0x12345678abceabcd) };
+    constexpr static XMHALF4 g_half4[] = { XMHALF4(HALF(0xabce), HALF(0xabcd), HALF(0xabcd), HALF(0xabcd)), XMHALF4(HALF(0xabce), HALF(0xabcd), HALF(0xabcd), HALF(0xabcd)) };
+    constexpr static XMHALF4 g_half4p[] = { XMHALF4(0x12345678abceabcd) };
 
-    XM_CONSTEXPR static XMSHORTN2 g_shortn2[] = { XMSHORTN2(int16_t(0x7bce), int16_t(0x7bcd)), XMSHORTN2(int16_t(0x7bce), int16_t(0x7bcd)) };
-    XM_CONSTEXPR static XMSHORTN2 g_shortn2p[] = { XMSHORTN2(0xabceabcd) };
-    XM_CONSTEXPR static XMUSHORTN2 g_shortun2[] = { XMUSHORTN2(uint16_t(0x7bce), uint16_t(0x7bcd)), XMUSHORTN2(uint16_t(0x7bce), uint16_t(0x7bcd)) };
-    XM_CONSTEXPR static XMUSHORTN2 g_shortun2p[] = { XMUSHORTN2(0xabceabcd) };
+    constexpr static XMSHORTN2 g_shortn2[] = { XMSHORTN2(int16_t(0x7bce), int16_t(0x7bcd)), XMSHORTN2(int16_t(0x7bce), int16_t(0x7bcd)) };
+    constexpr static XMSHORTN2 g_shortn2p[] = { XMSHORTN2(0xabceabcd) };
+    constexpr static XMUSHORTN2 g_shortun2[] = { XMUSHORTN2(uint16_t(0x7bce), uint16_t(0x7bcd)), XMUSHORTN2(uint16_t(0x7bce), uint16_t(0x7bcd)) };
+    constexpr static XMUSHORTN2 g_shortun2p[] = { XMUSHORTN2(0xabceabcd) };
 
-    XM_CONSTEXPR static XMSHORT2 g_short2[] = { XMSHORT2(int16_t(0x7bce), int16_t(0x7bcd)), XMSHORT2(int16_t(0x7bce), int16_t(0x7bcd)) };
-    XM_CONSTEXPR static XMSHORT2 g_short2p[] = { XMSHORT2(0xabceabcd) };
-    XM_CONSTEXPR static XMUSHORT2 g_shortu2[] = { XMUSHORT2(uint16_t(0x7bce), uint16_t(0x7bcd)), XMUSHORT2(uint16_t(0x7bce), uint16_t(0x7bcd)) };
-    XM_CONSTEXPR static XMUSHORT2 g_shortu2p[] = { XMUSHORT2(0xabceabcd) };
+    constexpr static XMSHORT2 g_short2[] = { XMSHORT2(int16_t(0x7bce), int16_t(0x7bcd)), XMSHORT2(int16_t(0x7bce), int16_t(0x7bcd)) };
+    constexpr static XMSHORT2 g_short2p[] = { XMSHORT2(0xabceabcd) };
+    constexpr static XMUSHORT2 g_shortu2[] = { XMUSHORT2(uint16_t(0x7bce), uint16_t(0x7bcd)), XMUSHORT2(uint16_t(0x7bce), uint16_t(0x7bcd)) };
+    constexpr static XMUSHORT2 g_shortu2p[] = { XMUSHORT2(0xabceabcd) };
 
-    XM_CONSTEXPR static XMSHORTN4 g_shortn4[] = { XMSHORTN4(int16_t(0x7bce), int16_t(0x7bcd), int16_t(0x7bce), int16_t(0x7bcd)), XMSHORTN4(int16_t(0x7bce), int16_t(0x7bcd), int16_t(0x7bce), int16_t(0x7bcd)) };
-    XM_CONSTEXPR static XMSHORTN4 g_shortn4p[] = { XMSHORTN4(0x12345678abceabcd) };
-    XM_CONSTEXPR static XMUSHORTN4 g_shortun4[] = { XMUSHORTN4(uint16_t(0x7bce), uint16_t(0x7bcd), uint16_t(0x7bce), uint16_t(0x7bcd)), XMUSHORTN4(uint16_t(0x7bce), uint16_t(0x7bcd), uint16_t(0x7bce), uint16_t(0x7bcd)) };
-    XM_CONSTEXPR static XMUSHORTN4 g_shortun4p[] = { XMUSHORTN4(0x12345678abceabcd) };
+    constexpr static XMSHORTN4 g_shortn4[] = { XMSHORTN4(int16_t(0x7bce), int16_t(0x7bcd), int16_t(0x7bce), int16_t(0x7bcd)), XMSHORTN4(int16_t(0x7bce), int16_t(0x7bcd), int16_t(0x7bce), int16_t(0x7bcd)) };
+    constexpr static XMSHORTN4 g_shortn4p[] = { XMSHORTN4(0x12345678abceabcd) };
+    constexpr static XMUSHORTN4 g_shortun4[] = { XMUSHORTN4(uint16_t(0x7bce), uint16_t(0x7bcd), uint16_t(0x7bce), uint16_t(0x7bcd)), XMUSHORTN4(uint16_t(0x7bce), uint16_t(0x7bcd), uint16_t(0x7bce), uint16_t(0x7bcd)) };
+    constexpr static XMUSHORTN4 g_shortun4p[] = { XMUSHORTN4(0x12345678abceabcd) };
 
-    XM_CONSTEXPR static XMSHORT4 g_short[] = { XMSHORT4(int16_t(0x7bce), int16_t(0x7bcd), int16_t(0x7bce), int16_t(0x7bcd)), XMSHORT4(int16_t(0x7bce), int16_t(0x7bcd), int16_t(0x7bce), int16_t(0x7bcd)) };
-    XM_CONSTEXPR static XMSHORT4 g_short4p[] = { XMSHORT4(0x12345678abceabcd) };
-    XM_CONSTEXPR static XMUSHORT4 g_shortu4[] = { XMUSHORT4(uint16_t(0x7bce), uint16_t(0x7bcd), uint16_t(0x7bce), uint16_t(0x7bcd)), XMUSHORT4(uint16_t(0x7bce), uint16_t(0x7bcd), uint16_t(0x7bce), uint16_t(0x7bcd)) };
-    XM_CONSTEXPR static XMUSHORT4 g_shortu4p[] = { XMUSHORT4(0x12345678abceabcd) };
+    constexpr static XMSHORT4 g_short[] = { XMSHORT4(int16_t(0x7bce), int16_t(0x7bcd), int16_t(0x7bce), int16_t(0x7bcd)), XMSHORT4(int16_t(0x7bce), int16_t(0x7bcd), int16_t(0x7bce), int16_t(0x7bcd)) };
+    constexpr static XMSHORT4 g_short4p[] = { XMSHORT4(0x12345678abceabcd) };
+    constexpr static XMUSHORT4 g_shortu4[] = { XMUSHORT4(uint16_t(0x7bce), uint16_t(0x7bcd), uint16_t(0x7bce), uint16_t(0x7bcd)), XMUSHORT4(uint16_t(0x7bce), uint16_t(0x7bcd), uint16_t(0x7bce), uint16_t(0x7bcd)) };
+    constexpr static XMUSHORT4 g_shortu4p[] = { XMUSHORT4(0x12345678abceabcd) };
 
-    XM_CONSTEXPR static XMBYTEN2 g_byten2[] = { XMBYTEN2(int8_t(0x7b), int8_t(0x7b)), XMBYTEN2(int8_t(0x7b), int8_t(0x7b)) };
-    XM_CONSTEXPR static XMBYTEN2 g_byten2p[] = { XMBYTEN2(0xabcd) };
-    XM_CONSTEXPR static XMUBYTEN2 g_byteun2[] = { XMUBYTEN2(uint8_t(0x7c), uint8_t(0x7b)), XMUBYTEN2(uint8_t(0x7b), uint8_t(0x7b)) };
-    XM_CONSTEXPR static XMUBYTEN2 g_byteun2p[] = { XMUBYTEN2(0xabce) };
+    constexpr static XMBYTEN2 g_byten2[] = { XMBYTEN2(int8_t(0x7b), int8_t(0x7b)), XMBYTEN2(int8_t(0x7b), int8_t(0x7b)) };
+    constexpr static XMBYTEN2 g_byten2p[] = { XMBYTEN2(0xabcd) };
+    constexpr static XMUBYTEN2 g_byteun2[] = { XMUBYTEN2(uint8_t(0x7c), uint8_t(0x7b)), XMUBYTEN2(uint8_t(0x7b), uint8_t(0x7b)) };
+    constexpr static XMUBYTEN2 g_byteun2p[] = { XMUBYTEN2(0xabce) };
 
-    XM_CONSTEXPR static XMBYTE2 g_byte2[] = { XMBYTE2(int8_t(0x7b), int8_t(0x7b)), XMBYTE2(int8_t(0x7b), int8_t(0x7d)) };
-    XM_CONSTEXPR static XMBYTE2 g_byte2p[] = { XMBYTE2(0xabce) };
-    XM_CONSTEXPR static XMUBYTE2 g_byteu2[] = { XMUBYTE2(uint8_t(0x7b), uint8_t(0x7d)), XMUBYTE2(uint8_t(0x7b), uint8_t(0x7d)) };
-    XM_CONSTEXPR static XMUBYTE2 g_byteu2p[] = { XMUBYTE2(0xabcd) };
+    constexpr static XMBYTE2 g_byte2[] = { XMBYTE2(int8_t(0x7b), int8_t(0x7b)), XMBYTE2(int8_t(0x7b), int8_t(0x7d)) };
+    constexpr static XMBYTE2 g_byte2p[] = { XMBYTE2(0xabce) };
+    constexpr static XMUBYTE2 g_byteu2[] = { XMUBYTE2(uint8_t(0x7b), uint8_t(0x7d)), XMUBYTE2(uint8_t(0x7b), uint8_t(0x7d)) };
+    constexpr static XMUBYTE2 g_byteu2p[] = { XMUBYTE2(0xabcd) };
 
-    XM_CONSTEXPR static XMBYTEN4 g_byten4[] = { XMBYTEN4(int8_t(0x7b), int8_t(0x7b), int8_t(0x7b), int8_t(0x7b)), XMBYTEN4(int8_t(0x7b), int8_t(0x7b), int8_t(0x7b), int8_t(0x7b)) };
-    XM_CONSTEXPR static XMBYTEN4 g_byten4p[] = { XMBYTEN4(0xabceabcd) };
-    XM_CONSTEXPR static XMUBYTEN4 g_byteun4[] = { XMUBYTEN4(uint8_t(0x7b), uint8_t(0x7b), uint8_t(0x7b), uint8_t(0x7b)), XMUBYTEN4(uint8_t(0x7b), uint8_t(0x7b), uint8_t(0x7b), uint8_t(0x7b)) };
-    XM_CONSTEXPR static XMUBYTEN4 g_byteun4p[] = { XMUBYTEN4(0xabceabcd) };
+    constexpr static XMBYTEN4 g_byten4[] = { XMBYTEN4(int8_t(0x7b), int8_t(0x7b), int8_t(0x7b), int8_t(0x7b)), XMBYTEN4(int8_t(0x7b), int8_t(0x7b), int8_t(0x7b), int8_t(0x7b)) };
+    constexpr static XMBYTEN4 g_byten4p[] = { XMBYTEN4(0xabceabcd) };
+    constexpr static XMUBYTEN4 g_byteun4[] = { XMUBYTEN4(uint8_t(0x7b), uint8_t(0x7b), uint8_t(0x7b), uint8_t(0x7b)), XMUBYTEN4(uint8_t(0x7b), uint8_t(0x7b), uint8_t(0x7b), uint8_t(0x7b)) };
+    constexpr static XMUBYTEN4 g_byteun4p[] = { XMUBYTEN4(0xabceabcd) };
 
-    XM_CONSTEXPR static XMBYTE4 g_byte[] = { XMBYTE4(int8_t(0x7b), int8_t(0x7b), int8_t(0x7b), int8_t(0x7b)), XMBYTE4(int8_t(0x7b), int8_t(0x7b), int8_t(0x7b), int8_t(0x7b)) };
-    XM_CONSTEXPR static XMBYTE4 g_byte4p[] = { XMBYTE4(0xabceabcd) };
-    XM_CONSTEXPR static XMUBYTE4 g_byteu4[] = { XMUBYTE4(uint8_t(0x7b), uint8_t(0x7b), uint8_t(0x7b), uint8_t(0x7b)), XMUBYTE4(uint8_t(0x7b), uint8_t(0x7b), uint8_t(0x7b), uint8_t(0x7b)) };
-    XM_CONSTEXPR static XMUBYTE4 g_byteu4p[] = { XMUBYTE4(0xabceabcd) };
+    constexpr static XMBYTE4 g_byte[] = { XMBYTE4(int8_t(0x7b), int8_t(0x7b), int8_t(0x7b), int8_t(0x7b)), XMBYTE4(int8_t(0x7b), int8_t(0x7b), int8_t(0x7b), int8_t(0x7b)) };
+    constexpr static XMBYTE4 g_byte4p[] = { XMBYTE4(0xabceabcd) };
+    constexpr static XMUBYTE4 g_byteu4[] = { XMUBYTE4(uint8_t(0x7b), uint8_t(0x7b), uint8_t(0x7b), uint8_t(0x7b)), XMUBYTE4(uint8_t(0x7b), uint8_t(0x7b), uint8_t(0x7b), uint8_t(0x7b)) };
+    constexpr static XMUBYTE4 g_byteu4p[] = { XMUBYTE4(0xabceabcd) };
 
-    XM_CONSTEXPR static XMU565 g_u656[] = { XMU565(uint8_t(12), uint8_t(6), uint8_t(15)) };
-    XM_CONSTEXPR static XMU565 g_u656p[] = { XMU565(0xabce) };
-    XM_CONSTEXPR static XMU555 g_u555[] = { XMU555(uint8_t(23), uint8_t(2), uint8_t(30), true) };
-    XM_CONSTEXPR static XMU555 g_u555p[] = { XMU555(0xabce) };
-    XM_CONSTEXPR static XMUNIBBLE4 g_u4444[] = { XMUNIBBLE4(uint8_t(3), uint8_t(11), uint8_t(14), uint8_t(5)) };
-    XM_CONSTEXPR static XMUNIBBLE4 g_u4444p[] = { XMUNIBBLE4(0xabce) };
+    constexpr static XMU565 g_u656[] = { XMU565(uint8_t(12), uint8_t(6), uint8_t(15)) };
+    constexpr static XMU565 g_u656p[] = { XMU565(0xabce) };
+    constexpr static XMU555 g_u555[] = { XMU555(uint8_t(23), uint8_t(2), uint8_t(30), true) };
+    constexpr static XMU555 g_u555p[] = { XMU555(0xabce) };
+    constexpr static XMUNIBBLE4 g_u4444[] = { XMUNIBBLE4(uint8_t(3), uint8_t(11), uint8_t(14), uint8_t(5)) };
+    constexpr static XMUNIBBLE4 g_u4444p[] = { XMUNIBBLE4(0xabce) };
    
-    XM_CONSTEXPR static XMFLOAT3PK g_3pk[] = { XMFLOAT3PK(0xabceabcd) };
-    XM_CONSTEXPR static XMFLOAT3SE g_3se[] = { XMFLOAT3SE(0xabceabcd) };
+    constexpr static XMFLOAT3PK g_3pk[] = { XMFLOAT3PK(0xabceabcd) };
+    constexpr static XMFLOAT3SE g_3se[] = { XMFLOAT3SE(0xabceabcd) };
 
-    XM_CONSTEXPR static XMXDECN4 g_xn4[] = { XMXDECN4(0xabceabcd) };
-    XM_CONSTEXPR static XMUDECN4 g_un4[] = { XMUDECN4(0xabceabcd) };
-    XM_CONSTEXPR static XMUDEC4 g_u4[] = { XMUDEC4(0xabceabcd) };
+    constexpr static XMXDECN4 g_xn4[] = { XMXDECN4(0xabceabcd) };
+    constexpr static XMUDECN4 g_un4[] = { XMUDECN4(0xabceabcd) };
+    constexpr static XMUDEC4 g_u4[] = { XMUDEC4(0xabceabcd) };
 
 #pragma warning(push)
 #pragma warning(disable : 4996)
@@ -142,9 +142,9 @@ namespace Test
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
-    XM_CONSTEXPR static XMXDEC4 g_x4[] = { XMXDEC4(0xabceabcd) };
-    XM_CONSTEXPR static XMDECN4 g_n4[] = { XMDECN4(0xabceabcd) };
-    XM_CONSTEXPR static XMDEC4 g_4[] = { XMDEC4(0xabceabcd) };
+    constexpr static XMXDEC4 g_x4[] = { XMXDEC4(0xabceabcd) };
+    constexpr static XMDECN4 g_n4[] = { XMDECN4(0xabceabcd) };
+    constexpr static XMDEC4 g_4[] = { XMDEC4(0xabceabcd) };
 
 #ifdef __clang__
 #pragma clang diagnostic pop
@@ -153,8 +153,8 @@ namespace Test
 #pragma warning(pop)
 
     // Collision
-    XM_CONSTEXPR static BoundingSphere g_sphere[] = { BoundingSphere(XMFLOAT3(1.f, 2.f, 3.f), 4.f), BoundingSphere(XMFLOAT3(5.f, 6.f, 7.f), 8.f) };
-    XM_CONSTEXPR static BoundingBox g_box[] = { BoundingBox(XMFLOAT3(1.f, 2.f, 3.f), XMFLOAT3(4.f, 4.f, 5.f)), BoundingBox(XMFLOAT3(6.f, 7.f, 8.f), XMFLOAT3(9.f, 10.f, 11.f)) };
-    XM_CONSTEXPR static BoundingOrientedBox g_obox[] = { BoundingOrientedBox(XMFLOAT3(1.f, 2.f, 3.f), XMFLOAT3(4.f, 4.f, 5.f), XMFLOAT4(0.f, 0.f, 0.f, 1.f)), BoundingOrientedBox(XMFLOAT3(6.f, 7.f, 8.f), XMFLOAT3(9.f, 10.f, 11.f), XMFLOAT4(0.461940f, 0.191342f, 0.191342f, 0.844623f)) };
-    XM_CONSTEXPR static BoundingFrustum g_frustum[] = { BoundingFrustum(XMFLOAT3(1.f, 1.f, 1.f), XMFLOAT4(0.f, 0.f, 0.f, 1.f), 2.f, -2.f, 2.f, -2.f, 1.f, 2.f), BoundingFrustum(XMFLOAT3(0.f, 0.f, 0.f), XMFLOAT4(0.f, 0.f, 0.f, 1.f), 1.f, -1.f, 1.f, -1.f, 0.1f, 1.f) };
+    constexpr static BoundingSphere g_sphere[] = { BoundingSphere(XMFLOAT3(1.f, 2.f, 3.f), 4.f), BoundingSphere(XMFLOAT3(5.f, 6.f, 7.f), 8.f) };
+    constexpr static BoundingBox g_box[] = { BoundingBox(XMFLOAT3(1.f, 2.f, 3.f), XMFLOAT3(4.f, 4.f, 5.f)), BoundingBox(XMFLOAT3(6.f, 7.f, 8.f), XMFLOAT3(9.f, 10.f, 11.f)) };
+    constexpr static BoundingOrientedBox g_obox[] = { BoundingOrientedBox(XMFLOAT3(1.f, 2.f, 3.f), XMFLOAT3(4.f, 4.f, 5.f), XMFLOAT4(0.f, 0.f, 0.f, 1.f)), BoundingOrientedBox(XMFLOAT3(6.f, 7.f, 8.f), XMFLOAT3(9.f, 10.f, 11.f), XMFLOAT4(0.461940f, 0.191342f, 0.191342f, 0.844623f)) };
+    constexpr static BoundingFrustum g_frustum[] = { BoundingFrustum(XMFLOAT3(1.f, 1.f, 1.f), XMFLOAT4(0.f, 0.f, 0.f, 1.f), 2.f, -2.f, 2.f, -2.f, 1.f, 2.f), BoundingFrustum(XMFLOAT3(0.f, 0.f, 0.f), XMFLOAT4(0.f, 0.f, 0.f, 1.f), 1.f, -1.f, 1.f, -1.f, 0.1f, 1.f) };
 }

--- a/math3/cpp17compat.cpp
+++ b/math3/cpp17compat.cpp
@@ -21,7 +21,7 @@
 // C4668 not defined as a preprocessor macro
 // C4820 padding added after data member
 
-#include <directxmath.h>
-#include <directxcolors.h>
-#include <directxpackedvector.h>
-#include <directxcollision.h>
+#include <DirectXMath.h>
+#include <DirectXColors.h>
+#include <DirectXPackedVector.h>
+#include <DirectXCollision.h>

--- a/math3/hdrtest.cpp
+++ b/math3/hdrtest.cpp
@@ -15,7 +15,7 @@
 // C4668 not defined as a preprocessor macro
 // C4820 padding added after data member
 
-#include <directxmath.h>
-#include <directxcolors.h>
-#include <directxpackedvector.h>
-#include <directxcollision.h>
+#include <DirectXMath.h>
+#include <DirectXColors.h>
+#include <DirectXPackedVector.h>
+#include <DirectXCollision.h>

--- a/math3/math3.cpp
+++ b/math3/math3.cpp
@@ -479,13 +479,13 @@ Cleanup:
 
 COMPARISON Compare(float a, float b)
 {
-    if (_isnan(a) && _isnan(b)) return EXACT;
-    if (_isnan(a) || _isnan(b)) return WAYOFF;
-    if (!_finite(a) && !_finite(b)) {
-        if (_copysign(1.0f, a) == _copysign(1.0f, b)) return EXACT;
+    if (std::isnan(a) && std::isnan(b)) return EXACT;
+    if (std::isnan(a) || std::isnan(b)) return WAYOFF;
+    if (!std::isfinite(a) && !std::isfinite(b)) {
+        if (std::copysign(1.0f, a) == std::copysign(1.0f, b)) return EXACT;
         else return WAYOFF;
     }
-    if (!_finite(a) || !_finite(b)) return WAYOFF;
+    if (!std::isfinite(a) || !std::isfinite(b)) return WAYOFF;
 
     if (a == b) return EXACT;
     float f = fabsf(b-a);

--- a/math3/math3.cpp
+++ b/math3/math3.cpp
@@ -811,7 +811,7 @@ BOOL WINAPI DllMain(HINSTANCE hInstance, uint32_t dwReason, LPVOID lpReserved)
 float GetRandomFloat(float fRange)
 {
     // Grab the raw integer value and convert to a float
-    float fx = static_cast<float>(rand());
+    float fx = static_cast<float>(XM_RAND());
     // The float is 0 to RAND_MAX inclusive
     fx = (fx / static_cast<float>(RAND_MAX)) * fRange;   // Normalize to 0-fRange
     return fx;
@@ -835,10 +835,10 @@ XMVECTOR GetRandomVector16(void)
     // are failing.
 
     // Grab the raw integer value and convert to a float
-    float fx = static_cast<float>(rand());
-    float fy = static_cast<float>(rand());
-    float fz = static_cast<float>(rand());
-    float fw = static_cast<float>(rand());
+    float fx = static_cast<float>(XM_RAND());
+    float fy = static_cast<float>(XM_RAND());
+    float fz = static_cast<float>(XM_RAND());
+    float fw = static_cast<float>(XM_RAND());
     // The float is 0 to RAND_MAX inclusive
     fx = fx / (static_cast<float>(RAND_MAX)/32.767f);   // Normalize to 0-32.767f
     fy = fy / (static_cast<float>(RAND_MAX)/32.767f);   
@@ -871,7 +871,7 @@ XMVECTOR GetRandomVector16(void)
 float GetRandomFloat16(void)
 {
     // Grab the raw integer value and convert to a float
-    float fx = static_cast<float>(rand());
+    float fx = static_cast<float>(XM_RAND());
     // The float is 0 to RAND_MAX inclusive
     fx = fx / (static_cast<float>(RAND_MAX)/32.767f);   // Normalize to 0-32.767f
     fx = fx-16.0f;          // Convert 0-32.767f to -16f - 16.767f
@@ -897,7 +897,7 @@ XMMATRIX GetRandomMatrix4(void)
         int j = 0;
         do {
             //range of -4 .. 4.192
-            m[i][j] = (static_cast<float>(rand()) / (static_cast<float>(RAND_MAX)/8.19175f)) - 4.0f;
+            m[i][j] = (static_cast<float>(XM_RAND()) / (static_cast<float>(RAND_MAX)/8.19175f)) - 4.0f;
         } while (++j<4);
     } while (++i<4);
     XMMATRIX r(&m[0][0]);

--- a/math3/math3.cpp
+++ b/math3/math3.cpp
@@ -435,6 +435,21 @@ void ParseCommandLine( _In_z_ TCHAR* szCmdLine )
     }
 }
 
+#ifdef __linux__
+#include <sys/types.h>
+#include <unistd.h>
+#include <linux/limits.h> 
+TCHAR* GetCommandLine() {
+    int pid = getpid();
+    char fname[PATH_MAX];
+    char* cmdline = new char[ARG_MAX];
+    snprintf(fname, sizeof fname, "/proc/%d/cmdline", pid);
+    FILE *fp = fopen(fname, "r");
+    fgets(cmdline, sizeof cmdline, fp);
+    fclose(fp);
+    return cmdline;
+}
+#endif
 
 int __cdecl main(void)
 {

--- a/math3/math3.cpp
+++ b/math3/math3.cpp
@@ -7,6 +7,8 @@
 // http://go.microsoft.com/fwlink/?LinkID=615560
 //-------------------------------------------------------------------------------------
 
+#include <cmath>
+
 #include "math3.h"
 
 #ifdef BUILD_FOR_LOGGER 

--- a/math3/math3.cpp
+++ b/math3/math3.cpp
@@ -128,9 +128,9 @@ HRESULT __stdcall Initialize(void)
 
     sprintf_s (filename, DATAPATH "math2.dat");
 
-    FILE* f=nullptr;
     int i;
-    if( fopen_s(&f, filename, "rt") )
+    FILE* f= fopen(filename, "rt");
+    if(f == nullptr)
     {
         PRINT("Warning: Couldn't open %s. f==0\nAssuming ALL tests\n", filename);
         for(i = 0; i < MAXTESTS; i++) {

--- a/math3/math3.h
+++ b/math3/math3.h
@@ -50,7 +50,7 @@
 #ifndef _MATH3_H_INCLUDED_
 #define _MATH3_H_INCLUDED_
 
-#if defined(_M_IX86) || defined(_M_X64) || defined(_M_ARM) || defined(_M_ARM64)
+#if defined(_M_IX86) || defined(_M_X64) || defined(_M_ARM) || defined(_M_ARM64) || defined(__i386__) || defined(__x86_64__) || defined(__arm__) || defined(__aarch64__)
 
 #pragma warning(push)
 #pragma warning(disable : 4005)
@@ -96,12 +96,41 @@
   #define NOMCX
 #pragma warning(pop)
 
+#ifdef _WIN32
   #include <Windows.h>
+#else
+  #include <cstdint>
+  #include <string.h>
+
+  typedef long HRESULT;
+  typedef char TCHAR;
+  typedef void* PVOID;
+  typedef void* LPVOID;
+  typedef int BOOL;
+  typedef float FLOAT;
+
+  #define S_OK (0)
+  #define E_FAIL (0x80004005)
+  #define TRUE (1)
+  #define FALSE (0)
+  #define SUCCEEDED(hr) (((HRESULT)(hr)) >= 0)
+  #define FAILED(hr) (((HRESULT)(hr)) < 0)
+  #define TEXT(x) (x)
+  #define _tcschr strchr
+  #define _tcsnicmp strncasecmp
+  #define _tcslen strlen
+#endif
   #define print printf
   #define DATAPATH ""
   static const int XB = 0;
   static const int PC = 1;
+#ifdef __GNUC__
+  #define BREAK { __asm__("int3"); }
+  #define DebugBreak() BREAK
+  #define __debugbreak() BREAK
+#else
   #define BREAK { _asm { int 3 }; }
+#endif
   typedef HRESULT (*APITEST_FUNC)(const char *TestName);
   #define LogProxy const char
 #else
@@ -120,6 +149,12 @@
 #define memcpy_s(d,ds,s,c) memcpy(d,s,c)
 #define sprintf_s(a,b) sprintf(a,b);
 #define fscanf_s(a,b,...) fscanf(a,b,__VA_ARGS__);
+#endif
+
+//calling conventions for GCC
+#if defined(__GNUC__) && !defined(__MINGW32__)
+#define __cdecl __attribute__((__cdecl__))
+#define __stdcall __attribute__((stdcall))
 #endif
 
 #ifdef BUILD_FOR_HARNESS
@@ -252,7 +287,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#ifdef _WIN32
 #include <tchar.h>
+#endif
 
 #include <DirectXMath.h>
 #include <DirectXColors.h>
@@ -272,7 +309,9 @@ typedef DirectX::XMVECTORU32 XMVECTORI;
 
 #pragma warning(push)
 #pragma warning(disable : 4987)
+#if defined(_WIN32) && !defined(__MINGW32__)
 #include <intrin.h>
+#endif
 #include <algorithm>
 #pragma warning(pop)
 

--- a/math3/math3.h
+++ b/math3/math3.h
@@ -157,6 +157,9 @@
 #define __stdcall __attribute__((stdcall))
 #endif
 
+//make random behaviour identical for all the compilers
+#define XM_RAND() (rand()%0x8000)
+
 #ifdef BUILD_FOR_HARNESS
     #include "h2.h"
 

--- a/math3/math3.h
+++ b/math3/math3.h
@@ -116,6 +116,12 @@
   #define BREAK { DebugBreak(); }
 #endif
 
+#ifndef _WIN32
+#define memcpy_s(d,ds,s,c) memcpy(d,s,c)
+#define sprintf_s(a,b) sprintf(a,b);
+#define fscanf_s(a,b,...) fscanf(a,b,__VA_ARGS__);
+#endif
+
 #ifdef BUILD_FOR_HARNESS
     #include "h2.h"
 

--- a/math3/math3tests.cpp
+++ b/math3/math3tests.cpp
@@ -1043,7 +1043,7 @@ HRESULT Test070(LogProxy* pLog)
 
     // TODO - Check for zeroing of partial loads
 
-    __declspec(align(16)) char c[64];
+    XM_ALIGNED_DATA(16) char c[64];
     int offset = 16;
     float f;
     int i, j; 
@@ -1301,7 +1301,7 @@ HRESULT Test072(LogProxy* pLog)
 
     // TODO - Check for zeroing of partial loads
 
-    __declspec(align(16)) char c[64];
+    XM_ALIGNED_DATA(16) char c[64];
     int offset = 16;
     float f;
     int i, j; 
@@ -1407,7 +1407,7 @@ HRESULT Test073(LogProxy* pLog)
     static_assert(std::is_nothrow_move_constructible<XMFLOAT3X3>::value, "Move Ctor.");
     static_assert(std::is_nothrow_move_assignable<XMFLOAT3X3>::value, "Move Assign.");
 
-    __declspec(align(16)) char c[112];
+    XM_ALIGNED_DATA(16) char c[112];
     int floatcount = 9;
     int offset = 16;
     float f;
@@ -1632,7 +1632,7 @@ HRESULT Test075(LogProxy* pLog)
     static_assert(std::is_nothrow_move_constructible<XMFLOAT4A>::value, "Move Ctor.");
     static_assert(std::is_nothrow_move_assignable<XMFLOAT4A>::value, "Move Assign.");
 
-    __declspec(align(16)) char c[64];
+    XM_ALIGNED_DATA(16) char c[64];
     int offset = 16;
     float f;
     int i, j; 
@@ -1967,7 +1967,7 @@ HRESULT Test078(LogProxy* pLog)
     static_assert(std::is_nothrow_move_constructible<XMFLOAT4X4>::value, "Move Ctor.");
     static_assert(std::is_nothrow_move_assignable<XMFLOAT4X4>::value, "Move Assign.");
 
-    __declspec(align(16)) char c[112];
+    XM_ALIGNED_DATA(16) char c[112];
     int floatcount = 16;
     int offset = 16;
     float f;
@@ -3698,7 +3698,7 @@ HRESULT Test179(LogProxy* pLog)
 {
 // XMStoreFloat2A / XMStoreInt2A
 
-    __declspec(align(16)) char c[64];
+    XM_ALIGNED_DATA(16) char c[64];
     int offset = 16;
     int i, j; 
     XMVECTORF32 v = {{1,2,3,4}};
@@ -3908,7 +3908,7 @@ HRESULT Test181(LogProxy* pLog)
 {
 //XMStoreFloat3A / XMStoreInt3A
 
-    __declspec(align(16)) char c[64];
+    XM_ALIGNED_DATA(16) char c[64];
     int offset = 16;
     float f;
     int i, j; 
@@ -4141,7 +4141,7 @@ HRESULT Test184(LogProxy* pLog)
 {
 // XMStoreFloat4A / XMStoreInt4A
 
-    __declspec(align(16)) char c[64];
+    XM_ALIGNED_DATA(16) char c[64];
     int offset = 16;
     float f;
     int i, j; 
@@ -4385,7 +4385,7 @@ HRESULT Test187(LogProxy* pLog)
 {
 // XMStoreFloat4x4A
 
-    __declspec(align(16)) char c[112];
+    XM_ALIGNED_DATA(16) char c[112];
     int floatcount = 16;
     int offset = 16;
     float f;
@@ -4760,7 +4760,7 @@ HRESULT Test497(LogProxy* pLog)
     }
 
     {
-        __declspec(align(16)) char c[112];
+        XM_ALIGNED_DATA(16) char c[112];
         const int floatcount = 12;
         const int offset = 16;
         int i, j;
@@ -4840,7 +4840,7 @@ HRESULT Test519(LogProxy* pLog)
     }
 
     {
-        __declspec(align(16)) char c[112];
+        XM_ALIGNED_DATA(16) char c[112];
         const int floatcount = 12;
         const int offset = 16;
         int i, j;
@@ -4897,7 +4897,7 @@ HRESULT Test498(LogProxy* pLog)
 {
 //XMStoreFloat4x3A (row-major)
 
-    __declspec(align(16)) char c[112];
+    XM_ALIGNED_DATA(16) char c[112];
     int floatcount = 12;
     int offset = 16;
     float f;
@@ -4947,7 +4947,7 @@ HRESULT Test521(LogProxy* pLog)
 {
     //XMStoreFloat3x4A (column-major) 
 
-    __declspec(align(16)) char c[112];
+    XM_ALIGNED_DATA(16) char c[112];
     int floatcount = 12;
     int offset = 16;
     float f;

--- a/math3/math3tests.cpp
+++ b/math3/math3tests.cpp
@@ -9,6 +9,8 @@
 
 #include "math3.h"
 
+#include <iterator>
+
 using namespace DirectX;
 using namespace DirectX::PackedVector;
 
@@ -996,7 +998,7 @@ HRESULT Test069(LogProxy* pLog)
     }
 
     int32_t sint[] = { 1, 1, 0, 0, -1, -1, 0x7FFFFFFF, int32_t(0xFFFFFFFF) };
-    for( i=0; i < _countof(sint)/intcount; ++i )
+    for( i=0; i < std::size(sint)/intcount; ++i )
     {
         XMVECTOR v = XMLoadSInt2( (const XMINT2*)&sint[i*intcount] );
 
@@ -1012,7 +1014,7 @@ HRESULT Test069(LogProxy* pLog)
     }
 
     uint32_t uint[] = { 1, 1, 0, 0, 0x0340c0f0, 0x82e02304, 0x7FFFFFFF, 0xFFFFFFFF };
-    for( i=0; i < _countof(uint)/intcount; ++i )
+    for( i=0; i < std::size(uint)/intcount; ++i )
     {
         XMVECTOR v = XMLoadUInt2( (const XMUINT2*)&uint[i*intcount] );
 
@@ -1252,7 +1254,7 @@ HRESULT Test071(LogProxy* pLog)
     }
 
     int32_t sint[] = { 1, 1, 1, 0, 0, 0, -1, -1, -1, 0x7FFFFFFF, int32_t(0xFFFFFFFF), 0x1F1F1F1F };
-    for( i=0; i < _countof(sint)/intcount; ++i )
+    for( i=0; i < std::size(sint)/intcount; ++i )
     {
         XMVECTOR v = XMLoadSInt3( (const XMINT3*)&sint[i*intcount] );
 
@@ -1269,7 +1271,7 @@ HRESULT Test071(LogProxy* pLog)
     }
 
     uint32_t uint[] = { 1, 1, 1, 0, 0, 0, 0x0340c0f0, 0x82e02304, 0x4839efcd, 0x7FFFFFFF, 0xFFFFFFFF, 0x1F1F1F1F  };
-    for( i=0; i < _countof(uint)/intcount; ++i )
+    for( i=0; i < std::size(uint)/intcount; ++i )
     {
         XMVECTOR v = XMLoadUInt3( (const XMUINT3*)&uint[i*intcount] );
 
@@ -1584,7 +1586,7 @@ HRESULT Test074(LogProxy* pLog)
     }
 
     int32_t sint[] = { 1, 1, 1, 1, 0, 0, 0, 0, -1, -1, -1, -1, 0x7FFFFFFF, int32_t(0xFFFFFFFF), 0x1F1F1F1F, int32_t(0xCDCDCDCD) };
-    for( i=0; i < _countof(sint)/intcount; ++i )
+    for( i=0; i < std::size(sint)/intcount; ++i )
     {
         v = XMLoadSInt4( (const XMINT4*)&sint[i*intcount] );
 
@@ -1601,7 +1603,7 @@ HRESULT Test074(LogProxy* pLog)
     }
 
     uint32_t uint[] = { 1, 1, 1, 1, 0, 0, 0, 0, 0x0340c0f0, 0x82e02304, 0x4839efcd, 0x838df7cd, 0x7FFFFFFF, 0xFFFFFFFF, 0x1F1F1F1F, 0xCDCDCDCD };
-    for( i=0; i < _countof(uint)/intcount; ++i )
+    for( i=0; i < std::size(uint)/intcount; ++i )
     {
         v = XMLoadUInt4( (const XMUINT4*)&uint[i*intcount] );
 
@@ -3660,7 +3662,7 @@ HRESULT Test178(LogProxy* pLog)
 
     static const XMVECTORF32 vsint[] = { { 1.f, 1.f, _Q_NAN, _Q_NAN }, { 0.f, 0.f, _Q_NAN, _Q_NAN }, { -1.f, -1.f, _Q_NAN, _Q_NAN }, { 2147483392.f, -1.f, _Q_NAN, _Q_NAN } };
     int32_t sint[] = { 1, 1, 0, 0, -1, -1, 0x7FFFFF00, -1 };
-    for( i=0; i < _countof(vsint); ++i )
+    for( i=0; i < std::size(vsint); ++i )
     {
         XMINT2 x;
         XMStoreSInt2( &x, vsint[i] );
@@ -3676,7 +3678,7 @@ HRESULT Test178(LogProxy* pLog)
 
     static const XMVECTORF32 vuint[] = { { 1.f, 1.f, 1.f, 1.f }, { 0.f, 0.f, 0.f, 0.f }, { 54575344.f, 2195727104.f, 1211756544.f, 2207119360.f }, { 2147483392.f, 4294967040.f, 134217728.f, 522133280.f } };
     uint32_t uint[] = { 1, 1, 0, 0, 0x0340c0f0, 0x82e02300, 0x7FFFFF00, 0xFFFFFF00 };
-    for( i=0; i < _countof(vuint); ++i )
+    for( i=0; i < std::size(vuint); ++i )
     {
         XMUINT2 x;
         XMStoreUInt2( &x, vuint[i] );
@@ -3865,7 +3867,7 @@ HRESULT Test180(LogProxy* pLog)
 
     static const XMVECTORF32 vsint[] = { { 1.f, 1.f, 1.f, _Q_NAN }, { 0.f, 0.f, 0.f, _Q_NAN }, { -1.f, -1.f, -1.f, _Q_NAN }, { 2147483392.f, -1.f, 134217728.f, _Q_NAN } };
     int32_t sint[] = { 1, 1, 1, 0, 0, 0, -1, -1, -1, 0x7FFFFF00, -1, 0x8000000 };
-    for( i=0; i < _countof(vsint); ++i )
+    for( i=0; i < std::size(vsint); ++i )
     {
         XMINT3 x;
         XMStoreSInt3( &x, vsint[i] );
@@ -3883,7 +3885,7 @@ HRESULT Test180(LogProxy* pLog)
 
     static const XMVECTORF32 vuint[] = { { 1.f, 1.f, 1.f, _Q_NAN }, { 0.f, 0.f, 0.f, _Q_NAN }, { 54575344.f, 2195727104.f, 1211756544.f, _Q_NAN }, { 2147483392.f, 4294967040.f, 134217728.f, _Q_NAN } };
     static uint32_t uint[] = { 1, 1, 1, 0, 0, 0, 0x0340c0f0, 0x82e02300, 0x4839f000, 0x7FFFFF00, 0xFFFFFF00, 0x8000000 };
-    for( i=0; i < _countof(vuint); ++i )
+    for( i=0; i < std::size(vuint); ++i )
     {
         XMUINT3 x;
         XMStoreUInt3( &x, vuint[i] );
@@ -4095,7 +4097,7 @@ HRESULT Test183(LogProxy* pLog)
 
     static const XMVECTORF32 vsint[] = { { 1.f, 1.f, 1.f, 1.f }, { 0.f, 0.f, 0.f, 0.f }, { -1.f, -1.f, -1.f, -1.f }, { 2147483392.f, -1.f, 134217728.f, 522133280.f } };
     int32_t sint[] = { 1, 1, 1, 1, 0, 0, 0, 0, -1, -1, -1, -1, 0x7FFFFF00, -1, 0x8000000, 0x1F1F1F20 };
-    for( i=0; i < _countof(vsint); ++i )
+    for( i=0; i < std::size(vsint); ++i )
     {
         XMINT4 x;
         XMStoreSInt4( &x, vsint[i] );
@@ -4114,7 +4116,7 @@ HRESULT Test183(LogProxy* pLog)
 
     static const XMVECTORF32 vuint[] = { { 1.f, 1.f, 1.f, 1.f }, { 0.f, 0.f, 0.f, 0.f }, { 54575344.f, 2195727104.f, 1211756544.f, 2207119360.f }, { 2147483392.f, 4294967040.f, 134217728.f, 522133280.f } };
     uint32_t uint[] = { 1, 1, 1, 1, 0, 0, 0, 0, 0x0340c0f0, 0x82e02300, 0x4839f000, 0x838df800, 0x7FFFFF00, 0xFFFFFF00, 0x8000000, 0x1F1F1F20 };
-    for( i=0; i < _countof(vuint); ++i )
+    for( i=0; i < std::size(vuint); ++i )
     {
         XMUINT4 x;
         XMStoreUInt4( &x, vuint[i] );
@@ -7754,7 +7756,7 @@ HRESULT Test590(LogProxy* pLog)
                             {1.f, 2.f, 3.f, 1.f},
                             {32.f, 480.f, 2016.f, 1.f} };
 
-    static_assert( _countof(s) == _countof(check), "bad test" );
+    static_assert( std::size(s) == std::size(check), "bad test" );
 
     for(int k = 0; k < countof(s); k++)
     {
@@ -7809,12 +7811,12 @@ HRESULT Test591(LogProxy* pLog)
                         {1.f, 2.f, 3.f, 1.f},
                         {32.f, 480.f, 2016.f, 1.f} };
 
-    static_assert( _countof(v) == _countof(check), "bad test" );
+    static_assert( std::size(v) == std::size(check), "bad test" );
 
     int n = 0;
     for(j = pc64k - 64; j <= pc64k + 64; j+=4)
     {
-        n = (n + 1) % (_countof(check));
+        n = (n + 1) % (std::size(check));
         for(i = 0; i < csize; i++)
         {
             c[i] = (char)(~i & 0xff);

--- a/math3/math3tests.cpp
+++ b/math3/math3tests.cpp
@@ -630,7 +630,7 @@ HRESULT Test062(LogProxy* pLog)
                     
                     for(i = 0; i < (int)dwNumItems; i++) 
                     {
-                        int num = rand() % countof(checka);
+                        int num = XM_RAND() % countof(checka);
                         *(float*)&( pbIn[offset + i*ins[j]])  = fa[num];
                         *(HALF*)&(pbChk[offset + i*outs[j]]) = checka[num];
                         
@@ -767,7 +767,7 @@ HRESULT Test065(LogProxy* pLog)
 
                     for(i = 0; i < (int)dwNumItems; i++) 
                     {
-                        int num = rand() % countof(checka);		            
+                        int num = XM_RAND() % countof(checka);		            
                         *(HALF*)&( pbIn[offset + i*ins[j]]) = checka[num];
                         *(float*)&(pbChk[offset + i*outs[j]]) = fa[num];
                     }
@@ -2168,10 +2168,10 @@ HRESULT Test081(LogProxy* pLog)
     }
 
     for(int k = 0; k < 15; k++) {
-        uint32_t a = rand() & 0x3ff; if(a == 0x200) a = 0;
-        uint32_t b = rand() & 0x3ff; if(b == 0x200) b = 0;
-        uint32_t c = rand() & 0x3ff; if(c == 0x200) c = 0;
-        uint32_t d = rand() & 0x3; 
+        uint32_t a = XM_RAND() & 0x3ff; if(a == 0x200) a = 0;
+        uint32_t b = XM_RAND() & 0x3ff; if(b == 0x200) b = 0;
+        uint32_t c = XM_RAND() & 0x3ff; if(c == 0x200) c = 0;
+        uint32_t d = XM_RAND() & 0x3; 
         XMXDECN4 src;
         XMVECTORF32 chk= {{
             ((float)(a&0x1ff))/511.f-((a&0x200)?(512.f/511.f):0.f),
@@ -2223,8 +2223,8 @@ HRESULT Test082(LogProxy* pLog)
     }
 
     for(int k = 0; k < 15; k++) {
-        short a = (rand() + rand()) & 0xffff; if(a == -32768) a = 0;
-        short b = (rand() + rand()) & 0xffff; if(b == -32768) b = 0;
+        short a = (XM_RAND() + XM_RAND()) & 0xffff; if(a == -32768) a = 0;
+        short b = (XM_RAND() + XM_RAND()) & 0xffff; if(b == -32768) b = 0;
         XMVECTORF32 chk= {{a/32767.f, b/32767.f, _Q_NAN, _Q_NAN}};
         src.x=a; src.y=b;
 
@@ -2284,10 +2284,10 @@ HRESULT Test083(LogProxy* pLog)
     }
 
     for(int k = 0; k < 15; k++) {
-        short a = (rand() + rand()) & 0xffff; if(a == -32768) a = 0;
-        short b = (rand() + rand()) & 0xffff; if(b == -32768) b = 0;
-        short c = (rand() + rand()) & 0xffff; if(c == -32768) c = 0;
-        short d = (rand() + rand()) & 0xffff; if(d == -32768) d = 0;
+        short a = (XM_RAND() + XM_RAND()) & 0xffff; if(a == -32768) a = 0;
+        short b = (XM_RAND() + XM_RAND()) & 0xffff; if(b == -32768) b = 0;
+        short c = (XM_RAND() + XM_RAND()) & 0xffff; if(c == -32768) c = 0;
+        short d = (XM_RAND() + XM_RAND()) & 0xffff; if(d == -32768) d = 0;
         XMVECTORF32 chk= {{a/32767.f, b/32767.f, c/32767.f, d/32767.f}};
         src.x=a; src.y=b; src.z=c; src.w=d;
 
@@ -2326,8 +2326,8 @@ HRESULT Test125(LogProxy* pLog)
     int i, j;
     for(i = 0; i < 10; i++) {
         for(j = 0; j < 4; j++) {
-            l.v = XMVectorSetByIndex(l,((float)rand()) / 1000.f,j);
-            v.v = XMVectorSetByIndex(v,((float)rand()) / 1000.f,j);
+            l.v = XMVectorSetByIndex(l,((float)XM_RAND()) / 1000.f,j);
+            v.v = XMVectorSetByIndex(v,((float)XM_RAND()) / 1000.f,j);
         }
         XMVECTOR r = XMPlaneDot(l, v);
         XMVECTOR check = XMVectorReplicate(XMVectorGetX(l)*XMVectorGetX(v)+  XMVectorGetY(l)*XMVectorGetY(v)+  XMVectorGetZ(l)*XMVectorGetZ(v)+  XMVectorGetW(l)*XMVectorGetW(v));
@@ -2354,8 +2354,8 @@ HRESULT Test126(LogProxy* pLog)
     int i, j;
     for(i = 0; i < 10; i++) {
         for(j = 0; j < 4; j++) {
-            l.v = XMVectorSetByIndex(l,((float)rand()) / 1000.f,j);
-            v.v = XMVectorSetByIndex(v,((float)rand()) / 1000.f,j);
+            l.v = XMVectorSetByIndex(l,((float)XM_RAND()) / 1000.f,j);
+            v.v = XMVectorSetByIndex(v,((float)XM_RAND()) / 1000.f,j);
         }
         v.v = XMVectorSetW(v,_Q_NAN);
         XMVECTOR r = XMPlaneDotCoord(l, v);
@@ -2382,8 +2382,8 @@ HRESULT Test127(LogProxy* pLog)
     int i, j;
     for(i = 0; i < 10; i++) {
         for(j = 0; j < 4; j++) {
-            l.v = XMVectorSetByIndex(l,((float)rand()) / 1000.f,j);
-            v.v = XMVectorSetByIndex(v,((float)rand()) / 1000.f,j);
+            l.v = XMVectorSetByIndex(l,((float)XM_RAND()) / 1000.f,j);
+            v.v = XMVectorSetByIndex(v,((float)XM_RAND()) / 1000.f,j);
         }
         l.v = XMVectorSetW(l,_Q_NAN);
         v.v = XMVectorSetW(v,_Q_NAN);
@@ -2411,7 +2411,7 @@ HRESULT Test128(LogProxy* pLog)
     HRESULT ret = S_OK;
     for(j = 0; j < 16; j++) {
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -2427,7 +2427,7 @@ HRESULT Test128(LogProxy* pLog)
         }
         check = TRUE;
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -2453,8 +2453,8 @@ HRESULT Test129(LogProxy* pLog)
 
     for(int k = 0; k < 7; k++) {
         for(int i = 0; i < 4; i++) {
-            p.v = XMVectorSetByIndex(p,((float)rand())/2000.f - 8.f,i);
-            n.v = XMVectorSetByIndex(n,((float)rand())/2000.f - 8.f,i);
+            p.v = XMVectorSetByIndex(p,((float)XM_RAND())/2000.f - 8.f,i);
+            n.v = XMVectorSetByIndex(n,((float)XM_RAND())/2000.f - 8.f,i);
             check.v = XMVectorSetByIndex(check,XMVectorGetByIndex(n,i),i);
         }
         p.v = XMVectorSetW(p,_Q_NAN);
@@ -2550,7 +2550,7 @@ HRESULT Test130(LogProxy* pLog)
     int i;
     for(i = 0; i < 3; i++) {
         for(int j = 0; j < 4; j++) {
-            p[i] = XMVectorSetByIndex(p[i],((float)rand()) / 2000.f - 8.f,j);
+            p[i] = XMVectorSetByIndex(p[i],((float)XM_RAND()) / 2000.f - 8.f,j);
         }
         p[i] = XMVectorSetW(p[i],_Q_NAN);
     }
@@ -2589,15 +2589,15 @@ HRESULT Test131(LogProxy* pLog)
     XMVECTOR r;
     for(int k = 0; k < 8; k++) {
         for(int i = 0; i < 2; i++) {
-            l[i] = XMVectorSetX(l[i],((float)rand()) / 2000.f - 8.f);
-            l[i] = XMVectorSetY(l[i],((float)rand()) / 2000.f - 8.f);
-            l[i] = XMVectorSetZ(l[i],((float)rand()) / 2000.f - 8.f);
+            l[i] = XMVectorSetX(l[i],((float)XM_RAND()) / 2000.f - 8.f);
+            l[i] = XMVectorSetY(l[i],((float)XM_RAND()) / 2000.f - 8.f);
+            l[i] = XMVectorSetZ(l[i],((float)XM_RAND()) / 2000.f - 8.f);
             l[i] = XMVectorSetW(l[i],_Q_NAN);
         }
-        p = XMVectorSetX(p,((float)rand()) / 2000.f - 8.f);
-        p = XMVectorSetY(p,((float)rand()) / 2000.f - 8.f);
-        p = XMVectorSetZ(p,((float)rand()) / 2000.f - 8.f);
-        p = XMVectorSetW(p,((float)rand()) / 2000.f - 8.f);
+        p = XMVectorSetX(p,((float)XM_RAND()) / 2000.f - 8.f);
+        p = XMVectorSetY(p,((float)XM_RAND()) / 2000.f - 8.f);
+        p = XMVectorSetZ(p,((float)XM_RAND()) / 2000.f - 8.f);
+        p = XMVectorSetW(p,((float)XM_RAND()) / 2000.f - 8.f);
 
         if(fabs(XMVectorGetX(XMPlaneDot(p,l[0]-l[1]))) < .00001f) {
             FLOAT fxtemp = XMVectorGetX(p);
@@ -2646,7 +2646,7 @@ HRESULT Test132(LogProxy* pLog)
     for(k = 0; k < 8; k++) {
         for(i = 0; i < 2; i++) {
             for(j = 0; j < 4; j++) {
-                p[i] = XMVectorSetByIndex(p[i],((float)rand()) / 2000.f - 8.f,j);
+                p[i] = XMVectorSetByIndex(p[i],((float)XM_RAND()) / 2000.f - 8.f,j);
             }
         }
 
@@ -2791,7 +2791,7 @@ HRESULT Test136(LogProxy* pLog)
     HRESULT ret = S_OK;
     for(j = 0; j < 16; j++) {
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -2807,7 +2807,7 @@ HRESULT Test136(LogProxy* pLog)
         }
 
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -2836,9 +2836,9 @@ HRESULT Test137(LogProxy* pLog)
         float tmp[4][4];
         for(i = 0; i < 4; i++) {
             for(int j = 0; j < 4; j++) {
-                tmp[i][j] = ((float)rand())/2000.f - 8.f;
+                tmp[i][j] = ((float)XM_RAND())/2000.f - 8.f;
             }
-            v.v = XMVectorSetByIndex(v,((float)rand())/2000.f - 8.f,i);
+            v.v = XMVectorSetByIndex(v,((float)XM_RAND())/2000.f - 8.f,i);
         }
 #pragma warning( suppress : 6385 )
         XMMATRIX m( &tmp[0][0] );
@@ -2924,11 +2924,11 @@ HRESULT Test138(LogProxy* pLog)
                         for(i = 0; i < 4; i++) {
                             for(int j = 0; j < 4; j++) 
                             {
-                                tmp[i][j] = ((float)rand())/2000.f - 8.f;
+                                tmp[i][j] = ((float)XM_RAND())/2000.f - 8.f;
                             }
                             for(n = 0; n < count; n++) 
                             {
-                                v[n] = XMVectorSetByIndex(v[n],((float)rand())/2000.f - 8.f,i);
+                                v[n] = XMVectorSetByIndex(v[n],((float)XM_RAND())/2000.f - 8.f,i);
                             }
                         }
 #pragma warning( suppress : 6385 )
@@ -5047,10 +5047,10 @@ HRESULT Test509(LogProxy* pLog)
     }
 
     for(int k = 0; k < 15; k++) {
-        char a = (rand() + rand()) & 0xff;
-        char b = (rand() + rand()) & 0xff;
-        char c = (rand() + rand()) & 0xff;
-        char d = (rand() + rand()) & 0xff;
+        char a = (XM_RAND() + XM_RAND()) & 0xff;
+        char b = (XM_RAND() + XM_RAND()) & 0xff;
+        char c = (XM_RAND() + XM_RAND()) & 0xff;
+        char d = (XM_RAND() + XM_RAND()) & 0xff;
         XMVECTORF32 chk= {{float(a), float(b), float(c), float(d)}};
         src.x=a; src.y=b; src.z=c; src.w=d;
 
@@ -5110,10 +5110,10 @@ HRESULT Test510(LogProxy* pLog)
     }
 
     for(int k = 0; k < 15; k++) {
-        char a = (rand() + rand()) & 0xff; if(a == -128) a = 0;
-        char b = (rand() + rand()) & 0xff; if(b == -128) b = 0;
-        char c = (rand() + rand()) & 0xff; if(c == -128) c = 0;
-        char d = (rand() + rand()) & 0xff; if(d == -128) d = 0;
+        char a = (XM_RAND() + XM_RAND()) & 0xff; if(a == -128) a = 0;
+        char b = (XM_RAND() + XM_RAND()) & 0xff; if(b == -128) b = 0;
+        char c = (XM_RAND() + XM_RAND()) & 0xff; if(c == -128) c = 0;
+        char d = (XM_RAND() + XM_RAND()) & 0xff; if(d == -128) d = 0;
         XMVECTORF32 chk= {{a/127.0f, b/127.0f, c/127.0f, d/127.0f}};
         src.x=a; src.y=b; src.z=c; src.w=d;
 
@@ -5173,10 +5173,10 @@ HRESULT Test511(LogProxy* pLog)
     }
 
     for(int k = 0; k < 15; k++) {
-        unsigned char a = (rand() + rand()) & 0xff; 
-        unsigned char b = (rand() + rand()) & 0xff; 
-        unsigned char c = (rand() + rand()) & 0xff; 
-        unsigned char d = (rand() + rand()) & 0xff; 
+        unsigned char a = (XM_RAND() + XM_RAND()) & 0xff; 
+        unsigned char b = (XM_RAND() + XM_RAND()) & 0xff; 
+        unsigned char c = (XM_RAND() + XM_RAND()) & 0xff; 
+        unsigned char d = (XM_RAND() + XM_RAND()) & 0xff; 
         XMVECTORF32 chk= {{float(a), float(b), float(c), float(d)}};
         src.x=a; src.y=b; src.z=c; src.w=d;
 
@@ -5221,10 +5221,10 @@ HRESULT Test512(LogProxy* pLog)
     }
 
     for(int k = 0; k < 15; k++) {
-        unsigned char a = (rand() + rand()) & 0xff; 
-        unsigned char b = (rand() + rand()) & 0xff; 
-        unsigned char c = (rand() + rand()) & 0xff; 
-        unsigned char d = (rand() + rand()) & 0xff; 
+        unsigned char a = (XM_RAND() + XM_RAND()) & 0xff; 
+        unsigned char b = (XM_RAND() + XM_RAND()) & 0xff; 
+        unsigned char c = (XM_RAND() + XM_RAND()) & 0xff; 
+        unsigned char d = (XM_RAND() + XM_RAND()) & 0xff; 
         XMVECTORF32 chk= {{a/255.0f, b/255.0f, c/255.0f, d/255.0f}};
         src.x=a; src.y=b; src.z=c; src.w=d;
 
@@ -5276,10 +5276,10 @@ HRESULT Test513(LogProxy* pLog)
     }
 
     for(int k = 0; k < 15; k++) {
-        uint32_t a = rand() & 0x3ff; if(a == 0x200) a = 0;
-        uint32_t b = rand() & 0x3ff; if(b == 0x200) b = 0;
-        uint32_t c = rand() & 0x3ff; if(c == 0x200) c = 0;
-        uint32_t d = rand() & 0x3;   if(d == 0x2)   d = 0;
+        uint32_t a = XM_RAND() & 0x3ff; if(a == 0x200) a = 0;
+        uint32_t b = XM_RAND() & 0x3ff; if(b == 0x200) b = 0;
+        uint32_t c = XM_RAND() & 0x3ff; if(c == 0x200) c = 0;
+        uint32_t d = XM_RAND() & 0x3;   if(d == 0x2)   d = 0;
         XMDEC4 src;
         XMVECTORF32 chk= {{
             ((float)(a&0x1ff))-((a&0x200)?(512.f):0.f),
@@ -5328,10 +5328,10 @@ HRESULT Test514(LogProxy* pLog)
     }
 
     for(int k = 0; k < 15; k++) {
-        uint32_t a = rand() & 0x3ff; if(a == 0x200) a = 0;
-        uint32_t b = rand() & 0x3ff; if(b == 0x200) b = 0;
-        uint32_t c = rand() & 0x3ff; if(c == 0x200) c = 0;
-        uint32_t d = rand() & 0x3;   if(d == 0x2)   d = 0;
+        uint32_t a = XM_RAND() & 0x3ff; if(a == 0x200) a = 0;
+        uint32_t b = XM_RAND() & 0x3ff; if(b == 0x200) b = 0;
+        uint32_t c = XM_RAND() & 0x3ff; if(c == 0x200) c = 0;
+        uint32_t d = XM_RAND() & 0x3;   if(d == 0x2)   d = 0;
         XMDECN4 src;
         XMVECTORF32 chk= {{
             ((float)(a&0x1ff))/511.f-((a&0x200)?(512.f/511.f):0.f),
@@ -5386,10 +5386,10 @@ HRESULT Test515(LogProxy* pLog)
     }
 
     for(int k = 0; k < 15; k++) {
-        uint32_t a = rand() & 0x3ff; 
-        uint32_t b = rand() & 0x3ff; 
-        uint32_t c = rand() & 0x3ff; 
-        uint32_t d = rand() & 0x3;   
+        uint32_t a = XM_RAND() & 0x3ff; 
+        uint32_t b = XM_RAND() & 0x3ff; 
+        uint32_t c = XM_RAND() & 0x3ff; 
+        uint32_t d = XM_RAND() & 0x3;   
         XMUDEC4 src;
         XMVECTORF32 chk= {{(float)a, (float)b, (float)c, (float)d}};
 
@@ -5438,10 +5438,10 @@ HRESULT Test516(LogProxy* pLog)
         }
 
         for(int k = 0; k < 15; k++) {
-            uint32_t a = rand() & 0x3ff;
-            uint32_t b = rand() & 0x3ff;
-            uint32_t c = rand() & 0x3ff;
-            uint32_t d = rand() & 0x3;
+            uint32_t a = XM_RAND() & 0x3ff;
+            uint32_t b = XM_RAND() & 0x3ff;
+            uint32_t c = XM_RAND() & 0x3ff;
+            uint32_t d = XM_RAND() & 0x3;
             XMUDECN4 src;
             XMVECTORF32 chk= {{
                 (float)a/1023.f,
@@ -5483,10 +5483,10 @@ HRESULT Test516(LogProxy* pLog)
         }
 
         for(int k = 0; k < 15; k++) {
-            uint32_t a = rand() & 0x3ff;
-            uint32_t b = rand() & 0x3ff;
-            uint32_t c = rand() & 0x3ff;
-            uint32_t d = rand() & 0x3;
+            uint32_t a = XM_RAND() & 0x3ff;
+            uint32_t b = XM_RAND() & 0x3ff;
+            uint32_t c = XM_RAND() & 0x3ff;
+            uint32_t d = XM_RAND() & 0x3;
             XMUDECN4 src;
             XMVECTORF32 chk= {{
                 (float)( int32_t(a) - 0x180)/510.f,
@@ -5546,10 +5546,10 @@ HRESULT Test517(LogProxy* pLog)
     }
 
     for(int k = 0; k < 15; k++) {
-        uint32_t a = rand() & 0x3ff; if(a == 0x200) a = 0;
-        uint32_t b = rand() & 0x3ff; if(b == 0x200) b = 0;
-        uint32_t c = rand() & 0x3ff; if(c == 0x200) c = 0;
-        uint32_t d = rand() & 0x3;
+        uint32_t a = XM_RAND() & 0x3ff; if(a == 0x200) a = 0;
+        uint32_t b = XM_RAND() & 0x3ff; if(b == 0x200) b = 0;
+        uint32_t c = XM_RAND() & 0x3ff; if(c == 0x200) c = 0;
+        uint32_t d = XM_RAND() & 0x3;
         XMXDEC4 src;
         XMVECTORF32 chk= {{
             ((float)(a&0x1ff))-((a&0x200)?(512.f):0.f),
@@ -5606,10 +5606,10 @@ HRESULT Test524(LogProxy* pLog)
     }
 
     for(int k = 0; k < 15; k++) {
-        short a = (rand() + rand()) & 0xffff;
-        short b = (rand() + rand()) & 0xffff;
-        short c = (rand() + rand()) & 0xffff;
-        short d = (rand() + rand()) & 0xffff;
+        short a = (XM_RAND() + XM_RAND()) & 0xffff;
+        short b = (XM_RAND() + XM_RAND()) & 0xffff;
+        short c = (XM_RAND() + XM_RAND()) & 0xffff;
+        short d = (XM_RAND() + XM_RAND()) & 0xffff;
         XMVECTORF32 chk= {{(float)a, (float)b, (float)c, (float)d}};
         src.x=a; src.y=b; src.z=c; src.w=d;
 
@@ -5669,10 +5669,10 @@ HRESULT Test525(LogProxy* pLog)
     }
 
     for(int k = 0; k < 15; k++) {
-        unsigned short a = (rand() + rand()) & 0xffff;
-        unsigned short b = (rand() + rand()) & 0xffff;
-        unsigned short c = (rand() + rand()) & 0xffff;
-        unsigned short d = (rand() + rand()) & 0xffff;
+        unsigned short a = (XM_RAND() + XM_RAND()) & 0xffff;
+        unsigned short b = (XM_RAND() + XM_RAND()) & 0xffff;
+        unsigned short c = (XM_RAND() + XM_RAND()) & 0xffff;
+        unsigned short d = (XM_RAND() + XM_RAND()) & 0xffff;
         XMVECTORF32 chk= {{(float)a, (float)b, (float)c, (float)d}};
         src.x=a; src.y=b; src.z=c; src.w=d;
 
@@ -5717,10 +5717,10 @@ HRESULT Test526(LogProxy* pLog)
     }
 
     for(int k = 0; k < 15; k++) {
-        unsigned short a = (rand() + rand()) & 0xffff;
-        unsigned short b = (rand() + rand()) & 0xffff;
-        unsigned short c = (rand() + rand()) & 0xffff;
-        unsigned short d = (rand() + rand()) & 0xffff;
+        unsigned short a = (XM_RAND() + XM_RAND()) & 0xffff;
+        unsigned short b = (XM_RAND() + XM_RAND()) & 0xffff;
+        unsigned short c = (XM_RAND() + XM_RAND()) & 0xffff;
+        unsigned short d = (XM_RAND() + XM_RAND()) & 0xffff;
         XMVECTORF32 chk= {{(float)a / 65535.0f, (float)b / 65535.0f, (float)c / 65535.0f, (float)d / 65535.0f}};
         src.x=a; src.y=b; src.z=c; src.w=d;
 
@@ -5767,8 +5767,8 @@ HRESULT Test535(LogProxy* pLog)
     }
 
     for(int k = 0; k < 15; k++) {
-        short a = (rand() + rand()) & 0xffff;
-        short b = (rand() + rand()) & 0xffff;
+        short a = (XM_RAND() + XM_RAND()) & 0xffff;
+        short b = (XM_RAND() + XM_RAND()) & 0xffff;
         XMVECTORF32 chk= {{(float)a, (float)b, _Q_NAN, _Q_NAN}};
         src.x=a; src.y=b; 
 
@@ -5830,8 +5830,8 @@ HRESULT Test536(LogProxy* pLog)
     }
 
     for(int k = 0; k < 15; k++) {
-        unsigned short a = (rand() + rand()) & 0xffff;
-        unsigned short b = (rand() + rand()) & 0xffff;
+        unsigned short a = (XM_RAND() + XM_RAND()) & 0xffff;
+        unsigned short b = (XM_RAND() + XM_RAND()) & 0xffff;
         XMVECTORF32 chk= {{(float)a, (float)b, _Q_NAN, _Q_NAN}};
         src.x=a; src.y=b; 
 
@@ -5878,8 +5878,8 @@ HRESULT Test537(LogProxy* pLog)
     }
 
     for(int k = 0; k < 15; k++) {
-        unsigned short a = (rand() + rand()) & 0xffff;
-        unsigned short b = (rand() + rand()) & 0xffff;
+        unsigned short a = (XM_RAND() + XM_RAND()) & 0xffff;
+        unsigned short b = (XM_RAND() + XM_RAND()) & 0xffff;
         XMVECTORF32 chk= {{(float)a / 65535.0f, (float)b / 65535.0f, _Q_NAN, _Q_NAN}};
         src.x=a; src.y=b; 
 
@@ -7331,9 +7331,9 @@ HRESULT Test582(LogProxy* pLog)
 
     for(int k = 0; k < 15; k++)
     {
-        uint32_t a = rand() & 0x1f;
-        uint32_t b = rand() & 0x3f;
-        uint32_t c = rand() & 0x1f;
+        uint32_t a = XM_RAND() & 0x1f;
+        uint32_t b = XM_RAND() & 0x3f;
+        uint32_t c = XM_RAND() & 0x1f;
         XMU565 src;
         XMVECTORF32 chk= {{ ((float)(a&0x1f)),
                          ((float)(b&0x3f)),
@@ -7438,10 +7438,10 @@ HRESULT Test584(LogProxy* pLog)
 
     for(int k = 0; k < 15; k++)
     {
-        uint32_t a = rand() & 0xf;
-        uint32_t b = rand() & 0xf;
-        uint32_t c = rand() & 0xf;
-        uint32_t d = rand() & 0xf;
+        uint32_t a = XM_RAND() & 0xf;
+        uint32_t b = XM_RAND() & 0xf;
+        uint32_t c = XM_RAND() & 0xf;
+        uint32_t d = XM_RAND() & 0xf;
         XMUNIBBLE4 src;
         XMVECTORF32 chk= {{ ((float)(a&0xf)),
                          ((float)(b&0xf)),
@@ -7547,10 +7547,10 @@ HRESULT Test586(LogProxy* pLog)
 
     for(int k = 0; k < 15; k++)
     {
-        uint32_t a = rand() & 0x1f;
-        uint32_t b = rand() & 0x1f;
-        uint32_t c = rand() & 0x1f;
-        BOOL d = rand() & 0x1;
+        uint32_t a = XM_RAND() & 0x1f;
+        uint32_t b = XM_RAND() & 0x1f;
+        uint32_t c = XM_RAND() & 0x1f;
+        BOOL d = XM_RAND() & 0x1;
         XMU555 src;
         XMVECTORF32 chk= {{ ((float)(a&0x1f)),
                          ((float)(b&0x1f)),
@@ -7887,8 +7887,8 @@ HRESULT Test595(LogProxy* pLog)
 
     for(int k = 0; k < 15; ++k)
     {
-        char a = (char)(rand() & 0xff);
-        char b = (char)(rand() & 0xff);
+        char a = (char)(XM_RAND() & 0xff);
+        char b = (char)(XM_RAND() & 0xff);
 
         if ( a == -128 ) a = 0;
         if ( b == -128 ) b = 0;
@@ -7961,8 +7961,8 @@ HRESULT Test596(LogProxy* pLog)
 
     for(int k = 0; k < 15; ++k)
     {
-        char a = (char)(rand() & 0xff);
-        char b = (char)(rand() & 0xff);
+        char a = (char)(XM_RAND() & 0xff);
+        char b = (char)(XM_RAND() & 0xff);
 
         XMVECTORF32 chk= {(float)a, (float)b, _Q_NAN, _Q_NAN};
 
@@ -8032,8 +8032,8 @@ HRESULT Test597(LogProxy* pLog)
 
     for(int k = 0; k < 15; ++k)
     {
-        uint8_t a = (uint8_t)(rand() & 0xff);
-        uint8_t b = (uint8_t)(rand() & 0xff);
+        uint8_t a = (uint8_t)(XM_RAND() & 0xff);
+        uint8_t b = (uint8_t)(XM_RAND() & 0xff);
 
         XMVECTORF32 chk= {(float)(a/255.f), (float)(b/255.f), _Q_NAN, _Q_NAN};
 
@@ -8088,8 +8088,8 @@ HRESULT Test598(LogProxy* pLog)
 
     for(int k = 0; k < 15; ++k)
     {
-        uint8_t a = (uint8_t)(rand() & 0xff);
-        uint8_t b = (uint8_t)(rand() & 0xff);
+        uint8_t a = (uint8_t)(XM_RAND() & 0xff);
+        uint8_t b = (uint8_t)(XM_RAND() & 0xff);
 
         XMVECTORF32 chk= {(float)a, (float)b, _Q_NAN, _Q_NAN};
 

--- a/math3/nomovnttest.cpp
+++ b/math3/nomovnttest.cpp
@@ -16,7 +16,7 @@
 // C4820 padding added after data member
 
 #define _XM_NO_MOVNT_
-#include <directxmath.h>
-#include <directxcolors.h>
-#include <directxpackedvector.h>
-#include <directxcollision.h>
+#include <DirectXMath.h>
+#include <DirectXColors.h>
+#include <DirectXPackedVector.h>
+#include <DirectXCollision.h>

--- a/math3/permissive.cpp
+++ b/math3/permissive.cpp
@@ -15,7 +15,7 @@
 // C4668 not defined as a preprocessor macro
 // C4820 padding added after data member
 
-#include <directxmath.h>
-#include <directxcolors.h>
-#include <directxpackedvector.h>
-#include <directxcollision.h>
+#include <DirectXMath.h>
+#include <DirectXColors.h>
+#include <DirectXPackedVector.h>
+#include <DirectXCollision.h>

--- a/math3/xmcolor.cpp
+++ b/math3/xmcolor.cpp
@@ -84,7 +84,7 @@ HRESULT Test051(LogProxy* pLog)
     HRESULT ret = S_OK;
     for(j = 0; j < 16; j++) {
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -100,7 +100,7 @@ HRESULT Test051(LogProxy* pLog)
         }
         check = TRUE;
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -125,7 +125,7 @@ HRESULT Test052(LogProxy* pLog)
     HRESULT ret = S_OK;
     for(j = 0; j < 16; j++) {
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -142,7 +142,7 @@ HRESULT Test052(LogProxy* pLog)
 
         check = FALSE;
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -167,7 +167,7 @@ HRESULT Test053(LogProxy* pLog)
     HRESULT ret = S_OK;
     for(j = 0; j < 16; j++) {
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -183,7 +183,7 @@ HRESULT Test053(LogProxy* pLog)
         }
 
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -273,7 +273,7 @@ HRESULT Test056(LogProxy* pLog)
     HRESULT ret = S_OK;
     for(j = 0; j < 16; j++) {
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -289,7 +289,7 @@ HRESULT Test056(LogProxy* pLog)
         }
 
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -315,7 +315,7 @@ HRESULT Test057(LogProxy* pLog)
     HRESULT ret = S_OK;
     for(j = 0; j < 16; j++) {
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -331,7 +331,7 @@ HRESULT Test057(LogProxy* pLog)
         }
 
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -357,8 +357,8 @@ HRESULT Test058(LogProxy* pLog)
     XMVECTORF32 v1={}, v2={};
     for(int i = 0; i < 10; i++) {
         for(int j = 0; j < 4; j++) {
-            v1.v = XMVectorSetByIndex(v1,(float)rand() / 100.f,j);
-            v2.v = XMVectorSetByIndex(v2,(float)rand() / 100.f,j);
+            v1.v = XMVectorSetByIndex(v1,(float)XM_RAND() / 100.f,j);
+            v2.v = XMVectorSetByIndex(v2,(float)XM_RAND() / 100.f,j);
             check.v = XMVectorSetByIndex(check,XMVectorGetByIndex(v1,j) * XMVectorGetByIndex(v2,j),j);
         }
         XMVECTOR r = XMColorModulate(v1, v2);
@@ -407,7 +407,7 @@ HRESULT Test060(LogProxy* pLog)
     HRESULT ret = S_OK;
     for(j = 0; j < 16; j++) {
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -423,7 +423,7 @@ HRESULT Test060(LogProxy* pLog)
         }
 
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }

--- a/math3/xmmat.cpp
+++ b/math3/xmmat.cpp
@@ -160,7 +160,7 @@ HRESULT Test086(LogProxy* pLog)
         float tmp[4][4];
         for(i = 0; i < 4; i++) {
             for(j = 0; j < 4; j++) {
-                tmp[i][j] = ((float)rand()) / 100.f;
+                tmp[i][j] = ((float)XM_RAND()) / 100.f;
             }
         }
 #pragma warning( suppress : 6385 )
@@ -289,7 +289,7 @@ HRESULT Test088(LogProxy* pLog)
     for(k = 0; k < 8; k++) {
         for(i = 0; i < 4; i++) {
             for(j = 0; j < 4; j++) {
-                tmp[i][j] = ((float)rand()) / 1000.f;
+                tmp[i][j] = ((float)XM_RAND()) / 1000.f;
             }
         }
         detchk = getinv(4,&tmp[0][0],&tmpc[0][0]);
@@ -383,10 +383,10 @@ HRESULT Test090(LogProxy* pLog)
     float tmp[4][4];
     for(x = 0; x < 4; x++) {
         for(y = 0; y < 4; y++) {
-            tmp[x][y] = (((float)rand()) / 100.f) - 16.f;
+            tmp[x][y] = (((float)XM_RAND()) / 100.f) - 16.f;
         }
     }
-    tmp[rand() & 3][rand() & 3] = _Q_NAN;
+    tmp[XM_RAND() & 3][XM_RAND() & 3] = _Q_NAN;
 #pragma warning( suppress : 6385 )
     XMMATRIX m2( &tmp[0][0] );
     r = XMMatrixIsInfinite(m2); 
@@ -429,10 +429,10 @@ HRESULT Test091(LogProxy* pLog)
     float tmp[4][4];
     for(x = 0; x < 4; x++) {
         for(y = 0; y < 4; y++) {
-            tmp[x][y] = (((float)rand()) / 100.f) - 16.f;
+            tmp[x][y] = (((float)XM_RAND()) / 100.f) - 16.f;
         }
     }
-    tmp[rand() & 3][rand() & 3] = _INF;
+    tmp[XM_RAND() & 3][XM_RAND() & 3] = _INF;
 #pragma warning( suppress : 6385 )
     XMMATRIX m2( &tmp[0][0] );
     r = XMMatrixIsNaN(m2); 
@@ -1310,7 +1310,7 @@ HRESULT Test109(LogProxy* pLog)
     float angle;
     COMPARISON c;
 
-    v = XMVectorSet(((rand()/4000.f) + .1f),0,0,0);
+    v = XMVectorSet(((XM_RAND()/4000.f) + .1f),0,0,0);
     angle = 1.0f;
     check = XMMatrixRotationX(angle);
     m = XMMatrixRotationAxis(v, angle);
@@ -1323,7 +1323,7 @@ HRESULT Test109(LogProxy* pLog)
     } else {
         printi("%s: %d\n", TestName,c);
     }
-    v = XMVectorSet(0,((rand()/4000.f) + .1f),0,0);
+    v = XMVectorSet(0,((XM_RAND()/4000.f) + .1f),0,0);
     angle = 2.0f;
     check = XMMatrixRotationY(angle);
     m = XMMatrixRotationAxis(v, angle);
@@ -1336,7 +1336,7 @@ HRESULT Test109(LogProxy* pLog)
     } else {
         printi("%s: %d\n", TestName,c);
     }
-    v = XMVectorSet(0,0,((rand()/4000.f) + .1f),0);
+    v = XMVectorSet(0,0,((XM_RAND()/4000.f) + .1f),0);
     angle = 3.0f;
     check = XMMatrixRotationZ(angle);
     m = XMMatrixRotationAxis(v, angle);
@@ -1350,10 +1350,10 @@ HRESULT Test109(LogProxy* pLog)
         printi("%s: %d\n", TestName,c);
     }
     for(int k = 0; k < 10; k++) {
-        v = XMVectorSet(((float)rand()) / 4000.f - 4.f,((float)rand()) / 4000.f - 4.f,((float)rand()) / 4000.f - 4.f,((float)rand()) / 4000.f - 4.f);
-        angle = ((float)rand()) / 2000.f - 8.f;
+        v = XMVectorSet(((float)XM_RAND()) / 4000.f - 4.f,((float)XM_RAND()) / 4000.f - 4.f,((float)XM_RAND()) / 4000.f - 4.f,((float)XM_RAND()) / 4000.f - 4.f);
+        angle = ((float)XM_RAND()) / 2000.f - 8.f;
         m = XMMatrixRotationAxis(v,angle);
-        XMVECTOR v1 = v * ((((float)rand()) / 8000.f)+.1f); 
+        XMVECTOR v1 = v * ((((float)XM_RAND()) / 8000.f)+.1f); 
         XMVECTOR r = XMVector4Transform(v1,m);
         c = CompareXMVECTOR(r,v1,4);
         if(c > WITHINBIGEPSILON) {
@@ -1367,7 +1367,7 @@ HRESULT Test109(LogProxy* pLog)
         } else {
             printi("%s: %d\n", TestName, c);	
         }
-        XMVECTOR v2 = XMVectorSet(((float)rand()) / 4000.f - 4.f,((float)rand()) / 4000.f - 4.f,((float)rand()) / 4000.f - 4.f,((float)rand()) / 4000.f - 4.f);
+        XMVECTOR v2 = XMVectorSet(((float)XM_RAND()) / 4000.f - 4.f,((float)XM_RAND()) / 4000.f - 4.f,((float)XM_RAND()) / 4000.f - 4.f,((float)XM_RAND()) / 4000.f - 4.f);
         r = XMVector4Transform(v2,m);
         float dot1,dot2;
         dot1 = XMVectorGetX(XMVector3Dot(v2, v1));
@@ -1454,12 +1454,12 @@ HRESULT Test110(LogProxy* pLog)
         printi("%s: %d\n", TestName,c);
     }
     for(int k = 0; k < 10; k++) {
-        v = XMVectorSet(((float)rand()) / 4000.f - 4.f,((float)rand()) / 4000.f - 4.f,((float)rand()) / 4000.f - 4.f,((float)rand()) / 4000.f - 4.f);
+        v = XMVectorSet(((float)XM_RAND()) / 4000.f - 4.f,((float)XM_RAND()) / 4000.f - 4.f,((float)XM_RAND()) / 4000.f - 4.f,((float)XM_RAND()) / 4000.f - 4.f);
         float blah = 1.f/sqrtf(XMVectorGetX(v)*XMVectorGetX(v)+XMVectorGetY(v)*XMVectorGetY(v)+XMVectorGetZ(v)*XMVectorGetZ(v));
         v *= blah;
-        angle = ((float)rand()) / 2000.f - 8.f;
+        angle = ((float)XM_RAND()) / 2000.f - 8.f;
         m = XMMatrixRotationNormal(v,angle);
-        XMVECTOR v1 = v * ((((float)rand()) / 8000.f)+.1f); 
+        XMVECTOR v1 = v * ((((float)XM_RAND()) / 8000.f)+.1f); 
         XMVECTOR r = XMVector4Transform(v1,m);
         c = CompareXMVECTOR(r,v1,4);
         if(c > WITHINBIGEPSILON) {
@@ -1473,7 +1473,7 @@ HRESULT Test110(LogProxy* pLog)
         } else {
             printi("%s: %d\n", TestName, c);	
         }
-        XMVECTOR v2 = XMVectorSet(((float)rand()) / 4000.f - 4.f,((float)rand()) / 4000.f - 4.f,((float)rand()) / 4000.f - 4.f,((float)rand()) / 4000.f - 4.f);
+        XMVECTOR v2 = XMVectorSet(((float)XM_RAND()) / 4000.f - 4.f,((float)XM_RAND()) / 4000.f - 4.f,((float)XM_RAND()) / 4000.f - 4.f,((float)XM_RAND()) / 4000.f - 4.f);
         r = XMVector4Transform(v2,m);
         float dot1,dot2;
         dot1 = XMVectorGetX(XMVector3Dot(v2, v1));
@@ -1521,12 +1521,12 @@ HRESULT Test111(LogProxy* pLog)
     COMPARISON c;
     XMVECTOR q;
     for(int k = 0; k < 10; k++) {
-        v = XMVectorSet(((float)rand()) / 4000.f - 4.f,((float)rand()) / 4000.f - 4.f,((float)rand()) / 4000.f - 4.f,((float)rand()) / 4000.f - 4.f);
+        v = XMVectorSet(((float)XM_RAND()) / 4000.f - 4.f,((float)XM_RAND()) / 4000.f - 4.f,((float)XM_RAND()) / 4000.f - 4.f,((float)XM_RAND()) / 4000.f - 4.f);
         float vx=XMVectorGetX(v); float vy=XMVectorGetY(v); float vz=XMVectorGetZ(v); float vw=XMVectorGetW(v);
         float blah = 1.f/sqrtf(vx*vx+vy*vy+vz*vz);
         v *= blah;
         vx=XMVectorGetX(v); vy=XMVectorGetY(v); vz=XMVectorGetZ(v); vw=XMVectorGetW(v);
-        angle = ((float)rand()) / 2000.f - 8.f;
+        angle = ((float)XM_RAND()) / 2000.f - 8.f;
         float si = sinf(angle/2.f);
         float co = cosf(angle/2.f);
         q = XMVectorSet(vx * si,vy * si,vz * si,co);
@@ -1541,7 +1541,7 @@ HRESULT Test111(LogProxy* pLog)
         } else {
             printi("%s: %d\n", TestName, c);
         }
-        XMVECTOR v1 = v * ((((float)rand()) / 8000.f)+.1f); 
+        XMVECTOR v1 = v * ((((float)XM_RAND()) / 8000.f)+.1f); 
         XMVECTOR r = XMVector4Transform(v1,m);
         c = CompareXMVECTOR(r,v1,4);
         if(c > WITHINBIGEPSILON) {
@@ -1554,7 +1554,7 @@ HRESULT Test111(LogProxy* pLog)
         } else {
             printi("%s: %d\n", TestName, c);	
         }
-        XMVECTOR v2 = XMVectorSet(((float)rand()) / 4000.f - 4.f,((float)rand()) / 4000.f - 4.f,((float)rand()) / 4000.f - 4.f,((float)rand()) / 4000.f - 4.f);
+        XMVECTOR v2 = XMVectorSet(((float)XM_RAND()) / 4000.f - 4.f,((float)XM_RAND()) / 4000.f - 4.f,((float)XM_RAND()) / 4000.f - 4.f,((float)XM_RAND()) / 4000.f - 4.f);
         r = XMVector4Transform(v2,m);
         float dot1,dot2;
         dot1 = XMVectorGetX(XMVector3Dot(v2, v1));
@@ -1599,9 +1599,9 @@ HRESULT Test112(LogProxy* pLog)
     XMMATRIX m, check;
     for(int k = 0; k < 15; k++) {
         float y,p,r;
-        y = ((float)rand()) / 4000.f;
-        p = ((float)rand()) / 4000.f;
-        r = ((float)rand()) / 4000.f;
+        y = ((float)XM_RAND()) / 4000.f;
+        p = ((float)XM_RAND()) / 4000.f;
+        r = ((float)XM_RAND()) / 4000.f;
         float cy, sy, cp, sp, cr, sr;
         sy = sinf(y); cy = cosf(y);
         sp = sinf(p); cp = cosf(p);
@@ -1629,9 +1629,9 @@ HRESULT Test113(LogProxy* pLog)
     XMMATRIX m, check;
     for(int k = 0; k < 15; k++) {
         float y,p,r;
-        y = ((float)rand()) / 4000.f;
-        p = ((float)rand()) / 4000.f;
-        r = ((float)rand()) / 4000.f;
+        y = ((float)XM_RAND()) / 4000.f;
+        p = ((float)XM_RAND()) / 4000.f;
+        r = ((float)XM_RAND()) / 4000.f;
         float cy, sy, cp, sp, cr, sr;
         sy = sinf(y); cy = cosf(y);
         sp = sinf(p); cp = cosf(p);

--- a/math3/xmquat.cpp
+++ b/math3/xmquat.cpp
@@ -45,12 +45,12 @@ HRESULT Test139(LogProxy* pLog)
 
         for(k = 0; k < 10; k++) {
             for(int i = 0; i < 4; i++) {
-                q1.v = XMVectorSetByIndex(q1,((float)rand()) / 2000.f - 8.f,i);
-                q2.v = XMVectorSetByIndex(q2,((float)rand()) / 2000.f - 8.f,i);
-                q3.v = XMVectorSetByIndex(q3,((float)rand()) / 2000.f - 8.f,i);
+                q1.v = XMVectorSetByIndex(q1,((float)XM_RAND()) / 2000.f - 8.f,i);
+                q2.v = XMVectorSetByIndex(q2,((float)XM_RAND()) / 2000.f - 8.f,i);
+                q3.v = XMVectorSetByIndex(q3,((float)XM_RAND()) / 2000.f - 8.f,i);
             }
-            f = ((float)rand()) / 2000.f - 8.f;
-            g = ((float)rand()) / 2000.f - 8.f;
+            f = ((float)XM_RAND()) / 2000.f - 8.f;
+            g = ((float)XM_RAND()) / 2000.f - 8.f;
             r = XMQuaternionBaryCentric(q1,q2,q3,f,g);
             check = XMQuaternionSlerp(XMQuaternionSlerp(q1,q2,f+g),XMQuaternionSlerp(q1,q3,f+g),g/(f+g));
             c = CompareXMVECTOR(r,check,4);
@@ -92,12 +92,12 @@ HRESULT Test139(LogProxy* pLog)
         }
 
         for(k = 0; k < 10; k++) {
-            float f = ((float)rand()) / 2000.f - 8.f;
-            float g = ((float)rand()) / 2000.f - 8.f;
+            float f = ((float)XM_RAND()) / 2000.f - 8.f;
+            float g = ((float)XM_RAND()) / 2000.f - 8.f;
             for(int i = 0; i < 4; i++) {
-                q1.v = XMVectorSetByIndex(q1,((float)rand()) / 2000.f - 8.f,i);
-                q2.v = XMVectorSetByIndex(q2,((float)rand()) / 2000.f - 8.f,i);
-                q3.v = XMVectorSetByIndex(q3,((float)rand()) / 2000.f - 8.f,i);
+                q1.v = XMVectorSetByIndex(q1,((float)XM_RAND()) / 2000.f - 8.f,i);
+                q2.v = XMVectorSetByIndex(q2,((float)XM_RAND()) / 2000.f - 8.f,i);
+                q3.v = XMVectorSetByIndex(q3,((float)XM_RAND()) / 2000.f - 8.f,i);
                 F = XMVectorSetByIndex(F,f,i);
                 G = XMVectorSetByIndex(G,g,i);
             }
@@ -155,8 +155,8 @@ HRESULT Test141(LogProxy* pLog)
     int i, j;
     for(i = 0; i < 10; i++) {
         for(j = 0; j < 4; j++) {
-            l.v = XMVectorSetByIndex(l,((float)rand()) / 1000.f,j);
-            v.v = XMVectorSetByIndex(v,((float)rand()) / 1000.f,j);
+            l.v = XMVectorSetByIndex(l,((float)XM_RAND()) / 1000.f,j);
+            v.v = XMVectorSetByIndex(v,((float)XM_RAND()) / 1000.f,j);
         }
         XMVECTOR r = XMQuaternionDot(l, v);
         XMVECTOR check = XMVectorReplicate(XMVectorGetX(l)*XMVectorGetX(v)+  XMVectorGetY(l)*XMVectorGetY(v)+ XMVectorGetZ(l)*XMVectorGetZ(v)+  XMVectorGetW(l)*XMVectorGetW(v));
@@ -182,7 +182,7 @@ HRESULT Test142(LogProxy* pLog)
     HRESULT ret = S_OK;
     for(j = 0; j < 16; j++) {
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -198,7 +198,7 @@ HRESULT Test142(LogProxy* pLog)
         }
         check = TRUE;
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -228,7 +228,7 @@ HRESULT Test143(LogProxy* pLog)
     for(int k = 0; k < countof(q1); k++) {
         if(k > 2) {
             for(int i = 0; i < 4; i++) {
-                q1[k].v = XMVectorSetByIndex(q1[k],((float)rand()) / 2000.f - 8.f,i);
+                q1[k].v = XMVectorSetByIndex(q1[k],((float)XM_RAND()) / 2000.f - 8.f,i);
             }
             q1[k].v = 2 * XMQuaternionNormalize(q1[k]);
             q1[k].v = XMVectorSetW(q1[k],0);
@@ -494,7 +494,7 @@ HRESULT Test151(LogProxy* pLog)
     for(int k = 0; k < countof(q1); k++) {
         if(k > 3) {
             for(int i = 0; i < 4; i++) {
-                q1[k].v = XMVectorSetByIndex(q1[k],((float)rand()) / 2000.f - 8.f,i);
+                q1[k].v = XMVectorSetByIndex(q1[k],((float)XM_RAND()) / 2000.f - 8.f,i);
             }
             q1[k].v = XMQuaternionNormalize(q1[k]);
         }
@@ -521,8 +521,8 @@ HRESULT Test152(LogProxy* pLog)
     XMVECTORF32 v1={}, v2={};
     for(int i = 0; i < 10; i++) {
         for(int j = 0; j < 4; j++) {
-            v1.v = XMVectorSetByIndex(v1,(float)rand() / 1000.f,j);
-            v2.v = XMVectorSetByIndex(v2,(float)rand() / 1000.f,j);
+            v1.v = XMVectorSetByIndex(v1,(float)XM_RAND() / 1000.f,j);
+            v2.v = XMVectorSetByIndex(v2,(float)XM_RAND() / 1000.f,j);
         }
         FLOAT checkx = XMVectorGetW(v2) * XMVectorGetX(v1) + XMVectorGetX(v2) * XMVectorGetW(v1) + XMVectorGetY(v2) * XMVectorGetZ(v1) - XMVectorGetZ(v2) * XMVectorGetY(v1);
         FLOAT checky = XMVectorGetW(v2) * XMVectorGetY(v1) - XMVectorGetX(v2) * XMVectorGetZ(v1) + XMVectorGetY(v2) * XMVectorGetW(v1) + XMVectorGetZ(v2) * XMVectorGetX(v1);
@@ -619,7 +619,7 @@ HRESULT Test154(LogProxy* pLog)
     HRESULT ret = S_OK;
     for(j = 0; j < 16; j++) {
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -635,7 +635,7 @@ HRESULT Test154(LogProxy* pLog)
         }
 
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -686,8 +686,8 @@ HRESULT Test156(LogProxy* pLog)
     COMPARISON c;
 
     for(int k = 0; k < 10; k++) {
-        v = XMVectorSet(((float)rand()) / 4000.f - 4.f,((float)rand()) / 4000.f - 4.f,((float)rand()) / 4000.f - 4.f,(float)rand());
-        angle = ((float)rand()) / 2000.f - 8.f;
+        v = XMVectorSet(((float)XM_RAND()) / 4000.f - 4.f,((float)XM_RAND()) / 4000.f - 4.f,((float)XM_RAND()) / 4000.f - 4.f,(float)XM_RAND());
+        angle = ((float)XM_RAND()) / 2000.f - 8.f;
         XMVECTOR v1 = v * (sinf(angle/2.f) / sqrtf(XMVectorGetX(v)*XMVectorGetX(v)+XMVectorGetY(v)*XMVectorGetY(v)+XMVectorGetZ(v)*XMVectorGetZ(v)));
         check = XMVectorSet(XMVectorGetX(v1),XMVectorGetY(v1),XMVectorGetZ(v1),cosf(angle/2.f));
         m = XMQuaternionRotationAxis(v,angle);
@@ -713,7 +713,7 @@ HRESULT Test157(LogProxy* pLog)
     XMVECTORF32 q2,oq={};
     for(int k = 0; k < 10000; k++) {
         for(int i = 0; i < 4; i++) {
-            oq.v = XMVectorSetByIndex(oq,((float)rand()) / 2000.f - 8.f,i);
+            oq.v = XMVectorSetByIndex(oq,((float)XM_RAND()) / 2000.f - 8.f,i);
         }
         oq.v = XMQuaternionNormalize(oq);
         XMMATRIX m = XMMatrixRotationQuaternion(oq);
@@ -741,9 +741,9 @@ HRESULT Test158(LogProxy* pLog)
     COMPARISON c;
 
     for(int k = 0; k < 10; k++) {
-        v = XMVectorSet(((float)rand()) / 4000.f - 4.f,((float)rand()) / 4000.f - 4.f,((float)rand()) / 4000.f - 4.f,(float)rand());
+        v = XMVectorSet(((float)XM_RAND()) / 4000.f - 4.f,((float)XM_RAND()) / 4000.f - 4.f,((float)XM_RAND()) / 4000.f - 4.f,(float)XM_RAND());
         v *= 1.f/sqrtf(XMVectorGetX(v)*XMVectorGetX(v)+XMVectorGetY(v)*XMVectorGetY(v)+XMVectorGetZ(v)*XMVectorGetZ(v));
-        angle = ((float)rand()) / 2000.f - 8.f;
+        angle = ((float)XM_RAND()) / 2000.f - 8.f;
         XMVECTOR v1 = v * sinf(angle/2.f);
         check = XMVectorSet(XMVectorGetX(v1),XMVectorGetY(v1),XMVectorGetZ(v1),cosf(angle/2.f));
         m = XMQuaternionRotationNormal(v,angle);
@@ -768,9 +768,9 @@ HRESULT Test159(LogProxy* pLog)
     XMVECTOR m, check;
     for(int k = 0; k < 15; k++) {
         float y,p,r;
-        y = ((float)rand()) / 4000.f;
-        p = ((float)rand()) / 4000.f;
-        r = ((float)rand()) / 4000.f;
+        y = ((float)XM_RAND()) / 4000.f;
+        p = ((float)XM_RAND()) / 4000.f;
+        r = ((float)XM_RAND()) / 4000.f;
         float cy, sy, cp, sp, cr, sr;
         sy = sinf(y); cy = cosf(y);
         sp = sinf(p); cp = cosf(p);
@@ -802,9 +802,9 @@ HRESULT Test160(LogProxy* pLog)
     XMVECTOR m, check;
     for(int k = 0; k < 15; k++) {
         float y,p,r;
-        y = ((float)rand()) / 4000.f;
-        p = ((float)rand()) / 4000.f;
-        r = ((float)rand()) / 4000.f;
+        y = ((float)XM_RAND()) / 4000.f;
+        p = ((float)XM_RAND()) / 4000.f;
+        r = ((float)XM_RAND()) / 4000.f;
         float cy, sy, cp, sp, cr, sr;
         sy = sinf(y); cy = cosf(y);
         sp = sinf(p); cp = cosf(p);
@@ -853,12 +853,12 @@ HRESULT Test161(LogProxy* pLog)
         for(int k = 0; k < countof(q1); k++) {
             if(k > 2) {
                 for(int i = 0; i < 4; i++) {
-                    q1[k].v = XMVectorSetByIndex(q1[k],((float)rand()) / 2000.f - 8.f,i);
-                    q2[k].v = XMVectorSetByIndex(q2[k],((float)rand()) / 2000.f - 8.f,i);
+                    q1[k].v = XMVectorSetByIndex(q1[k],((float)XM_RAND()) / 2000.f - 8.f,i);
+                    q2[k].v = XMVectorSetByIndex(q2[k],((float)XM_RAND()) / 2000.f - 8.f,i);
                 }
                 q1[k].v = XMQuaternionNormalize(q1[k]);
                 q2[k].v = XMQuaternionNormalize(q2[k]);
-                t[k] = ((float)rand()) / 2000.f - 8.f;
+                t[k] = ((float)XM_RAND()) / 2000.f - 8.f;
             }
 
             r = XMQuaternionSlerp(q1[k], q2[k], t[k]);
@@ -891,10 +891,10 @@ HRESULT Test161(LogProxy* pLog)
 
         for(int k = 0; k < countof(q1); k++) {
             if(k > 2) {
-                float f = ((float)rand()) / 2000.f - 8.f;
+                float f = ((float)XM_RAND()) / 2000.f - 8.f;
                 for(int i = 0; i < 4; i++) {
-                    q1[k].v = XMVectorSetByIndex(q1[k],((float)rand()) / 2000.f - 8.f,i);
-                    q2[k].v = XMVectorSetByIndex(q2[k],((float)rand()) / 2000.f - 8.f,i);
+                    q1[k].v = XMVectorSetByIndex(q1[k],((float)XM_RAND()) / 2000.f - 8.f,i);
+                    q2[k].v = XMVectorSetByIndex(q2[k],((float)XM_RAND()) / 2000.f - 8.f,i);
                     T[k].v = XMVectorSetByIndex(T[k],f, i);
                 }
                 q1[k].v = XMQuaternionNormalize(q1[k]);
@@ -931,12 +931,12 @@ HRESULT Test162(LogProxy* pLog)
 
         for(int k = 0; k < 15; k++) {
             for(int i = 0; i < 4; i++) {
-                q1.v = XMVectorSetByIndex(q1,((float)rand()) / 2000.f - 8.f,i);
-                q2.v = XMVectorSetByIndex(q2,((float)rand()) / 2000.f - 8.f,i);
-                q3.v = XMVectorSetByIndex(q3,((float)rand()) / 2000.f - 8.f,i);
-                q4.v = XMVectorSetByIndex(q4,((float)rand()) / 2000.f - 8.f,i);
+                q1.v = XMVectorSetByIndex(q1,((float)XM_RAND()) / 2000.f - 8.f,i);
+                q2.v = XMVectorSetByIndex(q2,((float)XM_RAND()) / 2000.f - 8.f,i);
+                q3.v = XMVectorSetByIndex(q3,((float)XM_RAND()) / 2000.f - 8.f,i);
+                q4.v = XMVectorSetByIndex(q4,((float)XM_RAND()) / 2000.f - 8.f,i);
             }
-            t = ((float)rand()) / 2000.f - 8.f;
+            t = ((float)XM_RAND()) / 2000.f - 8.f;
             q1.v = XMQuaternionNormalize(q1);
             q2.v = XMQuaternionNormalize(q2);
             q3.v = XMQuaternionNormalize(q3);
@@ -964,12 +964,12 @@ HRESULT Test162(LogProxy* pLog)
         XMVECTORF32 T = {};
 
         for(int k = 0; k < 15; k++) {
-            float t = ((float)rand()) / 2000.f - 8.f;
+            float t = ((float)XM_RAND()) / 2000.f - 8.f;
             for(int i = 0; i < 4; i++) {
-                q1.v = XMVectorSetByIndex(q1,((float)rand()) / 2000.f - 8.f,i);
-                q2.v = XMVectorSetByIndex(q2,((float)rand()) / 2000.f - 8.f,i);
-                q3.v = XMVectorSetByIndex(q3,((float)rand()) / 2000.f - 8.f,i);
-                q4.v = XMVectorSetByIndex(q4,((float)rand()) / 2000.f - 8.f,i);
+                q1.v = XMVectorSetByIndex(q1,((float)XM_RAND()) / 2000.f - 8.f,i);
+                q2.v = XMVectorSetByIndex(q2,((float)XM_RAND()) / 2000.f - 8.f,i);
+                q3.v = XMVectorSetByIndex(q3,((float)XM_RAND()) / 2000.f - 8.f,i);
+                q4.v = XMVectorSetByIndex(q4,((float)XM_RAND()) / 2000.f - 8.f,i);
                 T.v = XMVectorSetByIndex(T,t,i);                
             }
             
@@ -1045,7 +1045,7 @@ HRESULT Test164(LogProxy* pLog)
     for(int k = 0; k < 15; k++) {
         bNegated = false;
         for(int i = 0; i < 4; i++) {
-            q.v = XMVectorSetByIndex(q,((float)rand()) / 2000.f - 8.f,i);
+            q.v = XMVectorSetByIndex(q,((float)XM_RAND()) / 2000.f - 8.f,i);
         }
         q.v = XMQuaternionNormalize(q);
         achk = 2*acosf(XMVectorGetW(q));

--- a/math3/xmvec.cpp
+++ b/math3/xmvec.cpp
@@ -7,6 +7,8 @@
 // http://go.microsoft.com/fwlink/?LinkID=615560
 //-------------------------------------------------------------------------------------
 
+#include <iterator>
+
 #include "math3.h"
 
 using namespace DirectX;
@@ -184,7 +186,7 @@ HRESULT Test281(LogProxy* pLog)
         {.125,.25,-.75,1000},  {-.3125,0,90,-2},  {-.1875,.25,89.25,998},
         {.1f,.2f,.3f,.4f},  {.5f,.6f,.7f,.8f},  {.6f,.8f,1,1.2f}
     };
-    for(int i = 0; i < _countof(f); i+=3) {
+    for(int i = 0; i < std::size(f); i+=3) {
         XMVECTOR v1= f[i];
         XMVECTOR v2 = f[i+1];
         XMVECTOR check = f[i+2];
@@ -247,7 +249,7 @@ HRESULT Test296(LogProxy* pLog)
         { .6f,.8f,1,1.2f },{ 3.6f,3.6f,3.6f,3.6f }
     };
 
-    for (int i = 0; i < _countof(f); i += 2) {
+    for (int i = 0; i < std::size(f); i += 2) {
         XMVECTOR v = f[i];
         XMVECTOR check = f[i + 1];
         XMVECTOR r = XMVectorSum(v);
@@ -932,7 +934,7 @@ HRESULT Test291(LogProxy* pLog)
         { _Q_NAN, _Q_NAN, _Q_NAN, _Q_NAN}, { _Q_NAN, _Q_NAN, _Q_NAN, _Q_NAN}, 
     };
 
-    for(size_t i = 0; i < _countof(f); i+=2) {
+    for(size_t i = 0; i < std::size(f); i+=2) {
         XMVECTOR v1= f[i];
         XMVECTOR check = f[i+1];
         XMVECTOR r = XMVectorCeiling(v1);
@@ -1277,7 +1279,7 @@ HRESULT Test300(LogProxy* pLog)
         { _Q_NAN, _Q_NAN, _Q_NAN, _Q_NAN}, { _Q_NAN, _Q_NAN, _Q_NAN, _Q_NAN}, 
     };
 
-    for(size_t i = 0; i < _countof(f); i+=2) {
+    for(size_t i = 0; i < std::size(f); i+=2) {
         XMVECTOR v1= f[i];
         XMVECTOR check = f[i+1];
         XMVECTOR r = XMVectorFloor(v1);
@@ -2634,7 +2636,7 @@ HRESULT Test328(LogProxy* pLog)
         {  -_INF,  -_INF,  -_INF,  -_INF}, {  -_INF,  -_INF,  -_INF,  -_INF}, 
         { _Q_NAN, _Q_NAN, _Q_NAN, _Q_NAN}, { _Q_NAN, _Q_NAN, _Q_NAN, _Q_NAN}, 
     };
-    for(size_t i = 0; i < _countof(f); i+=2) {
+    for(size_t i = 0; i < std::size(f); i+=2) {
         XMVECTOR v1= f[i];
         XMVECTOR check = f[i+1];
         XMVECTOR r = XMVectorRound(v1);
@@ -3554,7 +3556,7 @@ HRESULT Test352(LogProxy* pLog)
         { _Q_NAN, _Q_NAN, _Q_NAN, _Q_NAN}, { _Q_NAN, _Q_NAN, _Q_NAN, _Q_NAN}, 
     };
 
-    for(size_t i = 0; i < _countof(f); i+=2) {
+    for(size_t i = 0; i < std::size(f); i+=2) {
         XMVECTOR v1= f[i];
         XMVECTOR check = f[i+1];
         XMVECTOR r = XMVectorTruncate(v1);

--- a/math3/xmvec.cpp
+++ b/math3/xmvec.cpp
@@ -817,12 +817,12 @@ HRESULT Test289(LogProxy* pLog)
 
     for(k = 0; k < 10; k++) {
         for(int i = 0; i < 4; i++) {
-            q1.v = XMVectorSetByIndex(q1,((float)rand()) / 2000.f - 8.f,i);
-            q2.v = XMVectorSetByIndex(q2,((float)rand()) / 2000.f - 8.f,i);
-            q3.v = XMVectorSetByIndex(q3,((float)rand()) / 2000.f - 8.f,i);
+            q1.v = XMVectorSetByIndex(q1,((float)XM_RAND()) / 2000.f - 8.f,i);
+            q2.v = XMVectorSetByIndex(q2,((float)XM_RAND()) / 2000.f - 8.f,i);
+            q3.v = XMVectorSetByIndex(q3,((float)XM_RAND()) / 2000.f - 8.f,i);
         }
-        f = ((float)rand()) / 2000.f - 8.f;
-        g = ((float)rand()) / 2000.f - 8.f;
+        f = ((float)XM_RAND()) / 2000.f - 8.f;
+        g = ((float)XM_RAND()) / 2000.f - 8.f;
         r = XMVectorBaryCentric(q1,q2,q3,f,g);
         // q1+f*(q2-q1)+g*(q3-q1)
         check = XMVectorAdd(
@@ -845,11 +845,11 @@ HRESULT Test289(LogProxy* pLog)
     XMVECTORF32 G = {{1,1,1,1}};
     for(k = 0; k < 10; k++) {
         for(int i = 0; i < 4; i++) {
-            q1.v = XMVectorSetByIndex(q1,((float)rand()) / 2000.f - 8.f,i);
-            q2.v = XMVectorSetByIndex(q2,((float)rand()) / 2000.f - 8.f,i);
-            q3.v = XMVectorSetByIndex(q3,((float)rand()) / 2000.f - 8.f,i);
-            F.v  = XMVectorSetByIndex(F,((float)rand()) / 2000.f - 8.f,i);
-            G.v  = XMVectorSetByIndex(G,((float)rand()) / 2000.f - 8.f,i);
+            q1.v = XMVectorSetByIndex(q1,((float)XM_RAND()) / 2000.f - 8.f,i);
+            q2.v = XMVectorSetByIndex(q2,((float)XM_RAND()) / 2000.f - 8.f,i);
+            q3.v = XMVectorSetByIndex(q3,((float)XM_RAND()) / 2000.f - 8.f,i);
+            F.v  = XMVectorSetByIndex(F,((float)XM_RAND()) / 2000.f - 8.f,i);
+            G.v  = XMVectorSetByIndex(G,((float)XM_RAND()) / 2000.f - 8.f,i);
         }
         r = XMVectorBaryCentricV(q1,q2,q3,F,G);
         // q1+F*(q2-q1.v)+G*(q3-q1.v);
@@ -882,7 +882,7 @@ HRESULT Test290(LogProxy* pLog)
         do {
             int j = 0;
             do {
-                qarray[i].f[j] = ((float)rand()) / 2000.f - 8.f;
+                qarray[i].f[j] = ((float)XM_RAND()) / 2000.f - 8.f;
             } while (++j<4);
         } while (++i<4);
         // Load them up!
@@ -890,7 +890,7 @@ HRESULT Test290(LogProxy* pLog)
         XMVECTOR q2 = qarray[1];
         XMVECTOR q3 = qarray[2];
         XMVECTOR q4 = qarray[3];
-        float f = ((float)rand()) / 2000.f - 8.f;
+        float f = ((float)XM_RAND()) / 2000.f - 8.f;
         XMVECTOR r = XMVectorCatmullRom(q1,q2,q3,q4,f);
         XMVECTORF32 xcheck = {
             0.5f*((-f*f*f+2*f*f-f)*qarray[0].f[0]+(3*f*f*f-5*f*f+2)*qarray[1].f[0]+(-3*f*f*f+4*f*f+f)*qarray[2].f[0]+(f*f*f-f*f)*qarray[3].f[0]),
@@ -1165,7 +1165,7 @@ HRESULT Test297(LogProxy* pLog)
     HRESULT ret = S_OK;
     for(j = 0; j < 16; j++) {
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -1181,7 +1181,7 @@ HRESULT Test297(LogProxy* pLog)
             }
         }
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -1332,7 +1332,7 @@ HRESULT Test301(LogProxy* pLog)
     HRESULT ret = S_OK;
     for(j = 0; j < 16; j++) {
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -1370,7 +1370,7 @@ HRESULT Test302(LogProxy* pLog)
     HRESULT ret = S_OK;
     for(j = 0; j < 16; j++) {
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -1431,12 +1431,12 @@ HRESULT Test303(LogProxy* pLog)
 
     for(k = 0; k < 10; k++) {
         for(int i = 0; i < 4; i++) {
-            q1.v = XMVectorSetByIndex(q1,((float)rand()) / 2000.f - 8.f,i);
-            q2.v = XMVectorSetByIndex(q2,((float)rand()) / 2000.f - 8.f,i);
-            q3.v = XMVectorSetByIndex(q3,((float)rand()) / 2000.f - 8.f,i);
-            q4.v = XMVectorSetByIndex(q4,((float)rand()) / 2000.f - 8.f,i);
+            q1.v = XMVectorSetByIndex(q1,((float)XM_RAND()) / 2000.f - 8.f,i);
+            q2.v = XMVectorSetByIndex(q2,((float)XM_RAND()) / 2000.f - 8.f,i);
+            q3.v = XMVectorSetByIndex(q3,((float)XM_RAND()) / 2000.f - 8.f,i);
+            q4.v = XMVectorSetByIndex(q4,((float)XM_RAND()) / 2000.f - 8.f,i);
         }
-        f = ((float)rand()) / 2000.f - 8.f;
+        f = ((float)XM_RAND()) / 2000.f - 8.f;
         r = XMVectorHermite(q1,q2,q3,q4,f);
         // (2*f*f*f-3*f*f+1)*q1+(f*f*f-2*f*f+f)*q2+(-2*f*f*f+3*f*f)*q3+(f*f*f-f*f)*q4;
         check = XMVectorAdd(
@@ -1550,10 +1550,10 @@ HRESULT Test306(LogProxy* pLog)
     //XMVectorLerp
     for(k = 0; k < 10; k++) {
         for(int i = 0; i < 4; i++) {
-            q1.v = XMVectorSetByIndex(q1,((float)rand()) / 2000.f - 8.f,i);
-            q2.v = XMVectorSetByIndex(q2,((float)rand()) / 2000.f - 8.f,i);
+            q1.v = XMVectorSetByIndex(q1,((float)XM_RAND()) / 2000.f - 8.f,i);
+            q2.v = XMVectorSetByIndex(q2,((float)XM_RAND()) / 2000.f - 8.f,i);
         }
-        f = ((float)rand()) / 2000.f - 8.f;
+        f = ((float)XM_RAND()) / 2000.f - 8.f;
         r = XMVectorLerp(q1,q2,f);
         // q1+f*(q2-q1)
         check = XMVectorAdd(q1, XMVectorScale(XMVectorSubtract(q2, q1), f));
@@ -1571,9 +1571,9 @@ HRESULT Test306(LogProxy* pLog)
     XMVECTORF32 T = {{1,1,1,1}};
     for(k = 0; k < 10; k++) {
         for(int i = 0; i < 4; i++) {
-            q1.v = XMVectorSetByIndex(q1,((float)rand()) / 2000.f - 8.f,i);
-            q2.v = XMVectorSetByIndex(q2,((float)rand()) / 2000.f - 8.f,i);
-            T.v  = XMVectorSetByIndex(T,((float)rand()) / 2000.f - 8.f,i);
+            q1.v = XMVectorSetByIndex(q1,((float)XM_RAND()) / 2000.f - 8.f,i);
+            q2.v = XMVectorSetByIndex(q2,((float)XM_RAND()) / 2000.f - 8.f,i);
+            T.v  = XMVectorSetByIndex(T,((float)XM_RAND()) / 2000.f - 8.f,i);
         }
         r = XMVectorLerpV(q1,q2,T);
         // q1+T*(q2-q1);
@@ -1600,7 +1600,7 @@ HRESULT Test307(LogProxy* pLog)
     HRESULT ret = S_OK;
     for(j = 0; j < 16; j++) {
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -1639,7 +1639,7 @@ HRESULT Test308(LogProxy* pLog)
     HRESULT ret = S_OK;
     for(j = 0; j < 16; j++) {
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -1874,8 +1874,8 @@ HRESULT Test315(LogProxy* pLog)
     XMVECTORF32 check={};
     for(int i = 0; i < 10; i++) {
         for(int j = 0; j < 4; j++) {
-            v1.v = XMVectorSetByIndex(v1,(float)rand() / 100.f,j);
-            v2.v = XMVectorSetByIndex(v2,(float)rand() / 100.f,j);
+            v1.v = XMVectorSetByIndex(v1,(float)XM_RAND() / 100.f,j);
+            v2.v = XMVectorSetByIndex(v2,(float)XM_RAND() / 100.f,j);
             check.v = XMVectorSetByIndex(check,XMVectorGetByIndex(v1,j) * XMVectorGetByIndex(v2,j),j);
         }
         XMVECTOR r = XMVectorMultiply(v1, v2);
@@ -1952,9 +1952,9 @@ HRESULT Test316(LogProxy* pLog)
     }
     for(int i = 0; i < 10; i++) {
         for(int j = 0; j < 4; j++) {
-            v1.v = XMVectorSetByIndex(v1,(float)rand() / 100.f,j);
-            v2.v = XMVectorSetByIndex(v2,(float)rand() / 100.f,j);
-            v3.v = XMVectorSetByIndex(v3,(float)rand() / 100.f,j);
+            v1.v = XMVectorSetByIndex(v1,(float)XM_RAND() / 100.f,j);
+            v2.v = XMVectorSetByIndex(v2,(float)XM_RAND() / 100.f,j);
+            v3.v = XMVectorSetByIndex(v3,(float)XM_RAND() / 100.f,j);
             check.v = XMVectorSetByIndex(check,XMVectorGetByIndex(v1,j) * XMVectorGetByIndex(v2,j) + XMVectorGetByIndex(v3,j),j);
         }
         r = XMVectorMultiplyAdd(v1, v2, v3);
@@ -2008,8 +2008,8 @@ HRESULT Test317(LogProxy* pLog)
     for(j = 0; j < 16; j++) {
         for(k = 0; k < 2; k++) {
             for(i = 0; i < 4; i++) {
-                v1.v = XMVectorSetByIndex(v1,(float)(rand()) / 1000.f,i);
-                e.v = XMVectorSetByIndex(e,(float)(rand()) / 10000.f,i);
+                v1.v = XMVectorSetByIndex(v1,(float)(XM_RAND()) / 1000.f,i);
+                e.v = XMVectorSetByIndex(e,(float)(XM_RAND()) / 10000.f,i);
                 v2.v = XMVectorSetByIndex(v2,XMVectorGetByIndex(v1,i) + ((k & 1) ? 1 : -1) * ((j & (1 << i)) ? (XMVectorGetByIndex(e,i) + XMVectorGetByIndex(e,i)) : (XMVectorGetByIndex(e,i) / 2.f)),i);
                 check.v = XMVectorSetIntByIndex(check,(j & (1 << i)) ? 0 : 0xffffffff,i);
             }
@@ -2100,9 +2100,9 @@ HRESULT Test319(LogProxy* pLog)
     }
     for(int i = 0; i < 10; i++) {
         for(int j = 0; j < 4; j++) {
-            v1.v = XMVectorSetByIndex(v1,(float)rand() / 100.f,j);
-            v2.v = XMVectorSetByIndex(v2,(float)rand() / 100.f,j);
-            v3.v = XMVectorSetByIndex(v3,(float)rand() / 100.f,j);
+            v1.v = XMVectorSetByIndex(v1,(float)XM_RAND() / 100.f,j);
+            v2.v = XMVectorSetByIndex(v2,(float)XM_RAND() / 100.f,j);
+            v3.v = XMVectorSetByIndex(v3,(float)XM_RAND() / 100.f,j);
             check.v = XMVectorSetByIndex(check,XMVectorGetByIndex(v3,j) - (XMVectorGetByIndex(v1,j) * XMVectorGetByIndex(v2,j)),j);
         }
         r = XMVectorNegativeMultiplySubtract(v1, v2, v3);
@@ -2131,7 +2131,7 @@ HRESULT Test320(LogProxy* pLog)
     HRESULT ret = S_OK;
     for(j = 0; j < 16; j++) {
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -2203,7 +2203,7 @@ HRESULT Test321(LogProxy* pLog)
     HRESULT ret = S_OK;
     for(int k = 0; k < 8; k++) {
         for(int i = 0; i < 4; i++) {
-            in[i] = rand() & 7;
+            in[i] = XM_RAND() & 7;
             check.v = XMVectorSetByIndex(check,(float)(in[i]),i);
         }
         XMVECTOR r = XMVectorPermute(v1,v2,in[0],in[1],in[2],in[3]);
@@ -2796,7 +2796,7 @@ HRESULT Test331(LogProxy* pLog)
     for(int j = 0; j < 5; j++) {
         int i;
         for(i = 0; i < 4; i++) {
-            p[i] = rand() + (rand() << 14) + (rand() << 28);
+            p[i] = XM_RAND() + (XM_RAND() << 14) + (XM_RAND() << 28);
         }
         XMVECTOR vecp = XMVectorSetInt(p[0],p[1],p[2],p[3]);
         XMVECTORU32 r1;
@@ -2814,9 +2814,9 @@ HRESULT Test331(LogProxy* pLog)
         XMVECTORU32 v1;
         int i;
         for(i = 0; i < 4; i++) {
-            v0.u[i]= rand() + (rand() << 14) + (rand() << 28);
-            v1.u[i]= rand() + (rand() << 14) + (rand() << 28);
-            p[i] = rand() + (rand() << 14) + (rand() << 28);
+            v0.u[i]= XM_RAND() + (XM_RAND() << 14) + (XM_RAND() << 28);
+            v1.u[i]= XM_RAND() + (XM_RAND() << 14) + (XM_RAND() << 28);
+            p[i] = XM_RAND() + (XM_RAND() << 14) + (XM_RAND() << 28);
         }
         XMVECTOR vecp = XMVectorSetInt(p[0],p[1],p[2],p[3]);
         XMVECTORU32 r1;
@@ -2857,10 +2857,10 @@ HRESULT Test333(LogProxy* pLog)
     static const float f[] = {-20, 5, 0, 1, _Q_NAN, -_INF, 3, -.123f};
     HRESULT ret = S_OK;
     for(int k = 0; k < 15; k++) {
-        float p0 = f[rand()&7];
-        float p1 = f[rand()&7];
-        float p2 = f[rand()&7];
-        float p3 = f[rand()&7];
+        float p0 = f[XM_RAND()&7];
+        float p1 = f[XM_RAND()&7];
+        float p2 = f[XM_RAND()&7];
+        float p3 = f[XM_RAND()&7];
         XMVECTOR v = XMVectorSet(p1,p3,p0,p2);
         XMVECTORF32 check = {p1,p3,p0,p2};
         COMPARISON c = CompareXMVECTOR(v, check,4);
@@ -3622,8 +3622,8 @@ HRESULT Test440(LogProxy* pLog)
         XMVECTORF32 check={};
         int i;
         for(i = 0; i < 4; i++) {
-            v1.v = XMVectorSetIntByIndex(v1,rand() + (rand() << 14) + (rand() << 28),i);
-            v2.v = XMVectorSetIntByIndex(v2,(k & (1 << i)) ? XMVectorGetIntByIndex(v1,i) : XMVectorGetIntByIndex(v1,i) + 1 + rand(),i);
+            v1.v = XMVectorSetIntByIndex(v1,XM_RAND() + (XM_RAND() << 14) + (XM_RAND() << 28),i);
+            v2.v = XMVectorSetIntByIndex(v2,(k & (1 << i)) ? XMVectorGetIntByIndex(v1,i) : XMVectorGetIntByIndex(v1,i) + 1 + XM_RAND(),i);
             check.v = XMVectorSetIntByIndex(check,(k & (1 << i)) ? 0xffffffff : 0,i);
         }
         XMVECTOR r = XMVectorEqualInt(v1,v2);
@@ -3647,8 +3647,8 @@ HRESULT Test441(LogProxy* pLog)
         XMVECTORF32 check={};
         int i;
         for(i = 0; i < 4; i++) {
-            v1.v = XMVectorSetIntByIndex(v1,rand() + (rand() << 14) + (rand() << 28),i);
-            v2.v = XMVectorSetIntByIndex(v2,(k & (1 << i)) ? XMVectorGetIntByIndex(v1,i) : XMVectorGetIntByIndex(v1,i) + 1 + rand(),i);
+            v1.v = XMVectorSetIntByIndex(v1,XM_RAND() + (XM_RAND() << 14) + (XM_RAND() << 28),i);
+            v2.v = XMVectorSetIntByIndex(v2,(k & (1 << i)) ? XMVectorGetIntByIndex(v1,i) : XMVectorGetIntByIndex(v1,i) + 1 + XM_RAND(),i);
             check.v = XMVectorSetIntByIndex(check,(k & (1 << i)) ? 0: 0xffffffff,i);
         }
         XMVECTOR r = XMVectorNotEqualInt(v1,v2);
@@ -3721,7 +3721,7 @@ HRESULT Test454(LogProxy* pLog)
         int i;
         for(i = 0; i < 4; i++) {
             v1.v = XMVectorSetIntByIndex(v1,c[(k+i)&7],i);
-            v2.v = XMVectorSetIntByIndex(v2,c[rand()&7],i);
+            v2.v = XMVectorSetIntByIndex(v2,c[XM_RAND()&7],i);
             check.v = XMVectorSetIntByIndex(check,(XMVectorGetIntByIndex(v1,i) == XMVectorGetIntByIndex(v2,i)) ? 0xffffffff:0,i);
         }
         XMVECTOR r = XMVectorEqualInt(v1, v2);
@@ -3746,7 +3746,7 @@ HRESULT Test455(LogProxy* pLog)
         int i;
         for(i = 0; i < 4; i++) {
             v1.v = XMVectorSetIntByIndex(v1,c[(k+i)&7],i);
-            v2.v = XMVectorSetIntByIndex(v2,c[rand()&7],i);
+            v2.v = XMVectorSetIntByIndex(v2,c[XM_RAND()&7],i);
             check.v = XMVectorSetIntByIndex(check,(XMVectorGetIntByIndex(v1,i) != XMVectorGetIntByIndex(v2,i)) ? 0xffffffff:0,i);
         }
         XMVECTOR r = XMVectorNotEqualInt(v1, v2);
@@ -3771,7 +3771,7 @@ HRESULT Test456(LogProxy* pLog)
         int i;
         for(i = 0; i < 4; i++) {
             v1.v = XMVectorSetIntByIndex(v1,c[(k+i)&7],i);
-            v2.v = XMVectorSetIntByIndex(v2,c[rand()&7],i);
+            v2.v = XMVectorSetIntByIndex(v2,c[XM_RAND()&7],i);
             check.v = XMVectorSetIntByIndex(check,XMVectorGetIntByIndex(v1,i) & XMVectorGetIntByIndex(v2,i),i);
         }
         XMVECTOR r = XMVectorAndInt(v1, v2);
@@ -3795,8 +3795,8 @@ HRESULT Test457(LogProxy* pLog)
     for(int k = 0; k < 8; k++) {
         int i;
         for(i = 0; i < 4; i++) {
-            v1.v = XMVectorSetIntByIndex(v1,(k<countof(c))?c[k]:rand()+(rand()<<15)+(rand()<<20),i);
-            v2.v = XMVectorSetIntByIndex(v2,(k<countof(c)*2)?c[(k*3)%countof(c)]:rand()+(rand()<<15)+(rand()<<20),i);
+            v1.v = XMVectorSetIntByIndex(v1,(k<countof(c))?c[k]:XM_RAND()+(XM_RAND()<<15)+(XM_RAND()<<20),i);
+            v2.v = XMVectorSetIntByIndex(v2,(k<countof(c)*2)?c[(k*3)%countof(c)]:XM_RAND()+(XM_RAND()<<15)+(XM_RAND()<<20),i);
             check.v = XMVectorSetIntByIndex(check,XMVectorGetIntByIndex(v1,i) & (~XMVectorGetIntByIndex(v2,i)),i);
         }
         XMVECTOR r = XMVectorAndCInt(v1, v2);
@@ -3821,7 +3821,7 @@ HRESULT Test458(LogProxy* pLog)
         int i;
         for(i = 0; i < 4; i++) {
             v1.v = XMVectorSetIntByIndex(v1,c[(k+i)&7],i);
-            v2.v = XMVectorSetIntByIndex(v2,c[rand()&7],i);
+            v2.v = XMVectorSetIntByIndex(v2,c[XM_RAND()&7],i);
             check.v = XMVectorSetIntByIndex(check,XMVectorGetIntByIndex(v1,i) | XMVectorGetIntByIndex(v2,i),i);
         }
         XMVECTOR r = XMVectorOrInt(v1, v2);
@@ -3846,7 +3846,7 @@ HRESULT Test459(LogProxy* pLog)
         int i;
         for(i = 0; i < 4; i++) {
             v1.v = XMVectorSetIntByIndex(v1,c[(k+i)&7],i);
-            v2.v = XMVectorSetIntByIndex(v2,c[rand()&7],i);
+            v2.v = XMVectorSetIntByIndex(v2,c[XM_RAND()&7],i);
             check.v = XMVectorSetIntByIndex(check,(~XMVectorGetIntByIndex(v1,i)) & (~XMVectorGetIntByIndex(v2,i)),i);
         }
         XMVECTOR r = XMVectorNorInt(v1, v2);
@@ -3871,7 +3871,7 @@ HRESULT Test460(LogProxy* pLog)
         int i;
         for(i = 0; i < 4; i++) {
             v1.v = XMVectorSetIntByIndex(v1,c[(k+i)&7],i);
-            v2.v = XMVectorSetIntByIndex(v2,c[rand()&7],i);
+            v2.v = XMVectorSetIntByIndex(v2,c[XM_RAND()&7],i);
             check.v = XMVectorSetIntByIndex(check,XMVectorGetIntByIndex(v1,i) ^ XMVectorGetIntByIndex(v2,i),i);
         }
         XMVECTOR r = XMVectorXorInt(v1, v2);
@@ -4126,7 +4126,7 @@ HRESULT Test471(LogProxy* pLog)
         pWork = &TableZ[(i>>6)&7];
         float v1z = pWork->x;
         float v2z = pWork->y;
-        pWork = &TableW[rand()&7];
+        pWork = &TableW[XM_RAND()&7];
         float v1w = pWork->x;
         float v2w = pWork->y;
         XMVECTOR v1 = XMVectorSet(v1x,v1y,v1z,v1w);
@@ -4174,7 +4174,7 @@ HRESULT Test472(LogProxy* pLog)
         pWork = &TableZ[(i>>6)&7];
         float v1z = pWork->x;
         float v2z = pWork->y;
-        pWork = &TableW[rand()&7];
+        pWork = &TableW[XM_RAND()&7];
         float v1w = pWork->x;
         float v2w = pWork->y;
         XMVECTOR v1 = XMVectorSet(v1x,v1y,v1z,v1w);
@@ -4638,18 +4638,18 @@ HRESULT Test507(LogProxy* pLog)
     
     for(k = 0; k < 10; k++) {
         for(int i = 0; i < 4; i++) {
-            pos0 = XMVectorSetByIndex(pos0,((float)rand()) / 2000.f - 8.f,i);
-            tan0 = XMVectorSetByIndex(tan0,((float)rand()) / 2000.f - 8.f,i);
-            pos1 = XMVectorSetByIndex(pos1,((float)rand()) / 2000.f - 8.f,i);
-            tan1 = XMVectorSetByIndex(tan1,((float)rand()) / 2000.f - 8.f,i);
+            pos0 = XMVectorSetByIndex(pos0,((float)XM_RAND()) / 2000.f - 8.f,i);
+            tan0 = XMVectorSetByIndex(tan0,((float)XM_RAND()) / 2000.f - 8.f,i);
+            pos1 = XMVectorSetByIndex(pos1,((float)XM_RAND()) / 2000.f - 8.f,i);
+            tan1 = XMVectorSetByIndex(tan1,((float)XM_RAND()) / 2000.f - 8.f,i);
         }
 
 
 
-        f0 = ((float)rand()) / 2000.f - 8.f;
-        f1 = ((float)rand()) / 2000.f - 8.f;
-        f2 = ((float)rand()) / 2000.f - 8.f;
-        f3 = ((float)rand()) / 2000.f - 8.f;        
+        f0 = ((float)XM_RAND()) / 2000.f - 8.f;
+        f1 = ((float)XM_RAND()) / 2000.f - 8.f;
+        f2 = ((float)XM_RAND()) / 2000.f - 8.f;
+        f3 = ((float)XM_RAND()) / 2000.f - 8.f;        
         T = XMVectorSet(f0, f1, f2, f3);
 
         r = XMVectorHermiteV(pos0, tan0, pos1, tan1, T);
@@ -4695,7 +4695,7 @@ HRESULT Test508(LogProxy* pLog)
         do {
             int j = 0;
             do {
-                qarray[i].f[j] = ((float)rand()) / 2000.f - 8.f;
+                qarray[i].f[j] = ((float)XM_RAND()) / 2000.f - 8.f;
             } while (++j<4);
         } while (++i<5);
         // Load them up!
@@ -5068,11 +5068,11 @@ HRESULT Test592(LogProxy* pLog)
     XMVECTORF32 check={}, check2={};
 
     for(int i = 0; i < 10; i++) {
-        float s = (float)rand() / 100.f;
+        float s = (float)XM_RAND() / 100.f;
         s = (s > 0.f) ? (s+1.0f) : (s-1.0f); // Ensure non-zero
         for(int j = 0; j < 4; j++) {
-            float x = (float)rand() / 100.f;
-            float y = (float)rand() / 100.f;
+            float x = (float)XM_RAND() / 100.f;
+            float y = (float)XM_RAND() / 100.f;
             v1.v = XMVectorSetByIndex(v1,x,j);
             v2.v = XMVectorSetByIndex(v2,y,j);
             check.v = XMVectorSetByIndex(check,x / y,j);

--- a/math3/xmvec234.cpp
+++ b/math3/xmvec234.cpp
@@ -37,8 +37,8 @@ HRESULT Test193(LogProxy* pLog)
     XMVECTORF32 v1={}, v2={};
     for(k = 0; k < 10; k++) {
         for(i = 0; i < 4; i++) {
-            v1.v = XMVectorSetByIndex(v1,((float)rand()) / 2000.f - 8.f,i);
-            v2.v = XMVectorSetByIndex(v2,((float)rand()) / 2000.f - 8.f,i);
+            v1.v = XMVectorSetByIndex(v1,((float)XM_RAND()) / 2000.f - 8.f,i);
+            v2.v = XMVectorSetByIndex(v2,((float)XM_RAND()) / 2000.f - 8.f,i);
         }
         v1.v = XMVectorSetZ(v1,_Q_NAN);
         v1.v = XMVectorSetW(v1,_Q_NAN);
@@ -70,8 +70,8 @@ HRESULT Test194(LogProxy* pLog)
     XMVECTORF32 v1={}, v2={};
     for(k = 0; k < 10; k++) {
         for(i = 0; i < 4; i++) {
-            v1.v = XMVectorSetByIndex(v1,((float)rand()) / 2000.f - 8.f,i);
-            v2.v = XMVectorSetByIndex(v2,((float)rand()) / 2000.f - 8.f,i);
+            v1.v = XMVectorSetByIndex(v1,((float)XM_RAND()) / 2000.f - 8.f,i);
+            v2.v = XMVectorSetByIndex(v2,((float)XM_RAND()) / 2000.f - 8.f,i);
         }
         v1.v = XMVectorSetZ(v1,_Q_NAN);
         v1.v = XMVectorSetW(v1,_Q_NAN);
@@ -197,8 +197,8 @@ HRESULT Test197(LogProxy* pLog)
     int i, j;
     for(i = 0; i < 10; i++) {
         for(j = 0; j < 4; j++) {
-            l.v = XMVectorSetByIndex(l,((float)rand()) / 1000.f,j);
-            v.v = XMVectorSetByIndex(v,((float)rand()) / 1000.f,j);
+            l.v = XMVectorSetByIndex(l,((float)XM_RAND()) / 1000.f,j);
+            v.v = XMVectorSetByIndex(v,((float)XM_RAND()) / 1000.f,j);
         }
         l.v = XMVectorSetZ(l,_Q_NAN);
         v.v = XMVectorSetZ(v,_Q_NAN);
@@ -229,7 +229,7 @@ HRESULT Test198(LogProxy* pLog)
     HRESULT ret = S_OK;
     for(j = 0; j < 16; j++) {
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -245,7 +245,7 @@ HRESULT Test198(LogProxy* pLog)
         }
         check = TRUE;
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -270,7 +270,7 @@ HRESULT Test199(LogProxy* pLog)
     HRESULT ret = S_OK;
     for(j = 0; j < 16; j++) {
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -287,7 +287,7 @@ HRESULT Test199(LogProxy* pLog)
 
         check = FALSE;
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -312,7 +312,7 @@ HRESULT Test200(LogProxy* pLog)
     HRESULT ret = S_OK;
     for(j = 0; j < 16; j++) {
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -328,7 +328,7 @@ HRESULT Test200(LogProxy* pLog)
         }
 
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -518,7 +518,7 @@ HRESULT Test206(LogProxy* pLog)
     HRESULT ret = S_OK;
     for(j = 0; j < 16; j++) {
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -534,7 +534,7 @@ HRESULT Test206(LogProxy* pLog)
         }
 
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -560,7 +560,7 @@ HRESULT Test207(LogProxy* pLog)
     HRESULT ret = S_OK;
     for(j = 0; j < 16; j++) {
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -576,7 +576,7 @@ HRESULT Test207(LogProxy* pLog)
         }
 
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -637,8 +637,8 @@ HRESULT Test209(LogProxy* pLog)
     for(j = 0; j < 16; j++) {
         for(k = 0; k < 2; k++) {
             for(i = 0; i < 4; i++) {
-                v1.v = XMVectorSetByIndex(v1,(float)(rand()) / 1000.f,i);
-                e.v = XMVectorSetByIndex(e,(float)(rand()) / 10000.f,i);
+                v1.v = XMVectorSetByIndex(v1,(float)(XM_RAND()) / 1000.f,i);
+                e.v = XMVectorSetByIndex(e,(float)(XM_RAND()) / 10000.f,i);
                 v2.v = XMVectorSetByIndex(v2,XMVectorGetByIndex(v1,i) + ((k & 1) ? 1 : -1) * ((j & (1 << i)) ? (XMVectorGetByIndex(e,i) + XMVectorGetByIndex(e,i)) : (XMVectorGetByIndex(e,i) / 2.f)),i);
             }
             check = ((j & 3) ? FALSE : TRUE);
@@ -724,7 +724,7 @@ HRESULT Test211(LogProxy* pLog)
     HRESULT ret = S_OK;
     for(j = 0; j < 16; j++) {
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -740,7 +740,7 @@ HRESULT Test211(LogProxy* pLog)
         }
 
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -824,8 +824,8 @@ HRESULT Test214(LogProxy* pLog)
     int i,k;
     for(k = 0; k < 15; k++) {
         for(i = 0; i <4; i++) {
-            v1.v = XMVectorSetByIndex(v1,((float)rand()) / 2000.f - 8.f,i);
-            v2.v = XMVectorSetByIndex(v2,((float)rand()) / 2000.f - 8.f,i);
+            v1.v = XMVectorSetByIndex(v1,((float)XM_RAND()) / 2000.f - 8.f,i);
+            v2.v = XMVectorSetByIndex(v2,((float)XM_RAND()) / 2000.f - 8.f,i);
         }
         v1.v = XMVectorSetZ(v1,_Q_NAN);
         v1.v = XMVectorSetW(v1,_Q_NAN);
@@ -863,14 +863,14 @@ HRESULT Test215(LogProxy* pLog)
         XMVECTORF32 xv2;
         int i = 0;
         do {
-            xv1.f[i] = ((float)rand()) / 2000.f - 8.f;
-            xv2.f[i] = ((float)rand()) / 2000.f - 8.f;
+            xv1.f[i] = ((float)XM_RAND()) / 2000.f - 8.f;
+            xv2.f[i] = ((float)XM_RAND()) / 2000.f - 8.f;
         } while (++i<2);
         xv1.f[2] = _Q_NAN;
         xv1.f[3] = _Q_NAN;
         xv2.f[2] = _Q_NAN;
         xv2.f[3] = _Q_NAN;
-        float f = ((float)rand()) / 2000.f - 8.f;
+        float f = ((float)XM_RAND()) / 2000.f - 8.f;
     // Result = RefractionIndex * Incident - Normal * (RefractionIndex * dot(Incident, Normal) + 
     // sqrt(1 - RefractionIndex * RefractionIndex * (1 - dot(Incident, Normal) * dot(Incident, Normal))))
         float fdot = (xv1.f[0]*xv2.f[0])+(xv1.f[1]*xv2.f[1]);
@@ -905,8 +905,8 @@ HRESULT Test215(LogProxy* pLog)
         XMVECTORF32 xV;	
         int i = 0;
         do {
-            xv1.f[i] = ((float)rand()) / 2000.f - 8.f;
-            xv2.f[i] = ((float)rand()) / 2000.f - 8.f;
+            xv1.f[i] = ((float)XM_RAND()) / 2000.f - 8.f;
+            xv2.f[i] = ((float)XM_RAND()) / 2000.f - 8.f;
         } while (++i<2);
         xv1.f[2] = _Q_NAN;
         xv1.f[3] = _Q_NAN;
@@ -914,7 +914,7 @@ HRESULT Test215(LogProxy* pLog)
         xv2.f[3] = _Q_NAN;
         i = 0;
         do {
-            xV.f[i] = ((float)rand()) / 2000.f - 8.f;
+            xV.f[i] = ((float)XM_RAND()) / 2000.f - 8.f;
         } while (++i<4);
     // Result = RefractionIndex * Incident - Normal * (RefractionIndex * dot(Incident, Normal) + 
     // sqrt(1 - RefractionIndex * RefractionIndex * (1 - dot(Incident, Normal) * dot(Incident, Normal))))
@@ -969,9 +969,9 @@ HRESULT Test216(LogProxy* pLog)
         float tmp[4][4];
         for(int i = 0; i < 4; i++) {
             for(int j = 0; j < 4; j++) {
-                tmp[i][j] = ((float)rand())/2000.f - 8.f;
+                tmp[i][j] = ((float)XM_RAND())/2000.f - 8.f;
             }
-            v.v = XMVectorSetByIndex(v,((float)rand())/2000.f - 8.f,i);
+            v.v = XMVectorSetByIndex(v,((float)XM_RAND())/2000.f - 8.f,i);
         }
 #pragma warning( suppress : 6385 )
         XMMATRIX m( &tmp[0][0] );
@@ -1004,9 +1004,9 @@ HRESULT Test217(LogProxy* pLog)
         float tmp[4][4];
         for(int i = 0; i < 4; i++) {
             for(int j = 0; j < 4; j++) {
-                tmp[i][j] = ((float)rand())/2000.f - 8.f;
+                tmp[i][j] = ((float)XM_RAND())/2000.f - 8.f;
             }
-            v.v = XMVectorSetByIndex(v,((float)rand())/2000.f - 8.f,i);
+            v.v = XMVectorSetByIndex(v,((float)XM_RAND())/2000.f - 8.f,i);
         }
         v.v = XMVectorSetW(v,_Q_NAN);
         v.v = XMVectorSetZ(v,_Q_NAN);
@@ -1082,10 +1082,10 @@ HRESULT Test218(LogProxy* pLog)
                         float tmp[4][4];
                         for(int i = 0; i < 4; i++) {
                             for(int j = 0; j < 4; j++) {
-                                tmp[i][j] = ((float)rand())/2000.f - 8.f;
+                                tmp[i][j] = ((float)XM_RAND())/2000.f - 8.f;
                             }
                             for(n = 0; n < dwNumItems; n++) {
-                                v[n] = XMVectorSetByIndex(v[n],((float)rand())/2000.f - 8.f,i);
+                                v[n] = XMVectorSetByIndex(v[n],((float)XM_RAND())/2000.f - 8.f,i);
                                 v[n] = XMVectorSetZ(v[n],_Q_NAN);
                                 v[n] = XMVectorSetW(v[n],_Q_NAN);
                             }
@@ -1143,9 +1143,9 @@ HRESULT Test219(LogProxy* pLog)
         float tmp[4][4];
         for(int i = 0; i < 4; i++) {
             for(int j = 0; j < 4; j++) {
-                tmp[i][j] = ((float)rand())/2000.f - 8.f;
+                tmp[i][j] = ((float)XM_RAND())/2000.f - 8.f;
             }
-            v.v = XMVectorSetByIndex(v,((float)rand())/2000.f - 8.f,i);
+            v.v = XMVectorSetByIndex(v,((float)XM_RAND())/2000.f - 8.f,i);
         }
         v.v = XMVectorSetW(v,_Q_NAN);
         v.v = XMVectorSetZ(v,_Q_NAN);
@@ -1219,7 +1219,7 @@ HRESULT Test220(LogProxy* pLog)
                         {
                             for(int j = 0; j < 4; j++) 
                             {
-                                tmp[i][j] = ((float)rand())/2000.f - 8.f;
+                                tmp[i][j] = ((float)XM_RAND())/2000.f - 8.f;
                             }
                         }
 #pragma warning( suppress : 6385 )
@@ -1227,8 +1227,8 @@ HRESULT Test220(LogProxy* pLog)
                         
                         for(n = 0; n < dwNumItems; n++) 
                         {
-                            v[n].x = ((float)rand())/2000.f - 8.f;
-                            v[n].y = ((float)rand())/2000.f - 8.f;
+                            v[n].x = ((float)XM_RAND())/2000.f - 8.f;
+                            v[n].y = ((float)XM_RAND())/2000.f - 8.f;
                         }
                         
                         for(n = 0; n < dwNumItems; n++) {
@@ -1321,10 +1321,10 @@ HRESULT Test221(LogProxy* pLog)
                             float tmp[4][4];
                             for(int i = 0; i < 4; i++) {
                                 for(int j = 0; j < 4; j++) {
-                                    tmp[i][j] = ((float)rand())/2000.f - 8.f;
+                                    tmp[i][j] = ((float)XM_RAND())/2000.f - 8.f;
                                 }
                                 for(n = 0; n < dwNumItems; n++) {
-                                    v[n] = XMVectorSetByIndex(v[n],((float)rand())/2000.f - 8.f,i);
+                                    v[n] = XMVectorSetByIndex(v[n],((float)XM_RAND())/2000.f - 8.f,i);
                                     v[n] = XMVectorSetZ(v[n],_Q_NAN);
                                     v[n] = XMVectorSetW(v[n],_Q_NAN);
                                 }
@@ -1383,8 +1383,8 @@ HRESULT Test222(LogProxy* pLog)
     XMVECTORF32 v1={}, v2={};
     for(k = 0; k < 10; k++) {
         for(i = 0; i < 4; i++) {
-            v1.v = XMVectorSetByIndex(v1,((float)rand()) / 2000.f - 8.f,i);
-            v2.v = XMVectorSetByIndex(v2,((float)rand()) / 2000.f - 8.f,i);
+            v1.v = XMVectorSetByIndex(v1,((float)XM_RAND()) / 2000.f - 8.f,i);
+            v2.v = XMVectorSetByIndex(v2,((float)XM_RAND()) / 2000.f - 8.f,i);
         }
         v1.v = XMVector3Normalize(v1);
         v2.v = XMVector3Normalize(v2);
@@ -1442,8 +1442,8 @@ HRESULT Test223(LogProxy* pLog)
             int i;
             // Prepare the random tests
             for(i = 0; i < 4; i++) {
-                v1image.f[i] = (static_cast<float>(rand()) / 2000.f) - 8.f;
-                v2image.f[i] = (static_cast<float>(rand()) / 2000.f) - 8.f;
+                v1image.f[i] = (static_cast<float>(XM_RAND()) / 2000.f) - 8.f;
+                v2image.f[i] = (static_cast<float>(XM_RAND()) / 2000.f) - 8.f;
             }
             v1image.f[3] = _Q_NAN;
             v2image.f[3] = _Q_NAN;
@@ -1542,8 +1542,8 @@ HRESULT Test225(LogProxy* pLog)
     XMVECTORF32 v1={}, v2={};
     for(k = 0; k < 10; k++) {
         for(i = 0; i < 3; i++) {
-            v1.v = XMVectorSetByIndex(v1,((float)rand()) / 2000.f - 8.f,i);
-            v2.v = XMVectorSetByIndex(v2,((float)rand()) / 2000.f - 8.f,i);
+            v1.v = XMVectorSetByIndex(v1,((float)XM_RAND()) / 2000.f - 8.f,i);
+            v2.v = XMVectorSetByIndex(v2,((float)XM_RAND()) / 2000.f - 8.f,i);
         }
         v1.v = XMVectorSetW(v1,_Q_NAN);
         v2.v = XMVectorSetW(v2,_Q_NAN);
@@ -1614,8 +1614,8 @@ HRESULT Test227(LogProxy* pLog)
     int i, j;
     for(i = 0; i < 10; i++) {
         for(j = 0; j < 4; j++) {
-            l.v = XMVectorSetByIndex(l,((float)rand()) / 1000.f,j);
-            v.v = XMVectorSetByIndex(v,((float)rand()) / 1000.f,j);
+            l.v = XMVectorSetByIndex(l,((float)XM_RAND()) / 1000.f,j);
+            v.v = XMVectorSetByIndex(v,((float)XM_RAND()) / 1000.f,j);
         }
         l.v = XMVectorSetW(l,_Q_NAN);
         v.v = XMVectorSetW(v,_Q_NAN);
@@ -1644,7 +1644,7 @@ HRESULT Test228(LogProxy* pLog)
     HRESULT ret = S_OK;
     for(j = 0; j < 16; j++) {
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -1661,7 +1661,7 @@ HRESULT Test228(LogProxy* pLog)
         }
         check = TRUE;
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -1686,7 +1686,7 @@ HRESULT Test229(LogProxy* pLog)
     HRESULT ret = S_OK;
     for(j = 0; j < 16; j++) {
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -1703,7 +1703,7 @@ HRESULT Test229(LogProxy* pLog)
 
         check = FALSE;
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -1728,7 +1728,7 @@ HRESULT Test230(LogProxy* pLog)
     HRESULT ret = S_OK;
     for(j = 0; j < 16; j++) {
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -1744,7 +1744,7 @@ HRESULT Test230(LogProxy* pLog)
         }
 
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -1902,7 +1902,7 @@ HRESULT Test235(LogProxy* pLog)
     HRESULT ret = S_OK;
     for(j = 0; j < 16; j++) {
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -1918,7 +1918,7 @@ HRESULT Test235(LogProxy* pLog)
         }
 
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -1944,7 +1944,7 @@ HRESULT Test236(LogProxy* pLog)
     HRESULT ret = S_OK;
     for(j = 0; j < 16; j++) {
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -1960,7 +1960,7 @@ HRESULT Test236(LogProxy* pLog)
         }
 
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -2022,8 +2022,8 @@ HRESULT Test238(LogProxy* pLog)
     for(j = 0; j < 16; j++) {
         for(k = 0; k < 2; k++) {
             for(i = 0; i < 4; i++) {
-                v1.v = XMVectorSetByIndex(v1,(float)(rand()) / 1000.f,i);
-                e.v = XMVectorSetByIndex(e,(float)(rand()) / 10000.f,i);
+                v1.v = XMVectorSetByIndex(v1,(float)(XM_RAND()) / 1000.f,i);
+                e.v = XMVectorSetByIndex(e,(float)(XM_RAND()) / 10000.f,i);
                 v2.v = XMVectorSetByIndex(v2,XMVectorGetByIndex(v1,i) + ((k & 1) ? 1 : -1) * ((j & (1 << i)) ? (XMVectorGetByIndex(e,i) + XMVectorGetByIndex(e,i)) : (XMVectorGetByIndex(e,i) / 2.f)),i);
             }
             check = ((j & 7) ? FALSE : TRUE);
@@ -2108,7 +2108,7 @@ HRESULT Test240(LogProxy* pLog)
     HRESULT ret = S_OK;
     for(j = 0; j < 16; j++) {
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -2124,7 +2124,7 @@ HRESULT Test240(LogProxy* pLog)
         }
 
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -2224,10 +2224,10 @@ HRESULT Test242(LogProxy* pLog)
     XMMATRIX temp;
 
     for(int i = 0; i < 16; i++) {
-        vx = (float)(rand() % 1000);
-        vy = (float)(rand() % 1000);
-        vw = (float)(rand() % 1000);
-        vh = (float)(rand() % 1000);
+        vx = (float)(XM_RAND() % 1000);
+        vy = (float)(XM_RAND() % 1000);
+        vw = (float)(XM_RAND() % 1000);
+        vh = (float)(XM_RAND() % 1000);
         nz = GetRandomFloat16();
         xz = GetRandomFloat16();
         pr = GetRandomMatrix4();
@@ -2327,12 +2327,12 @@ HRESULT Test243(LogProxy* pLog)
                 {
                     for (OutStrideIndex=0; OutStrideIndex<countof(outs); OutStrideIndex++)
                     {
-                        i = rand() % 16;
+                        i = XM_RAND() % 16;
 
-                        vx = (float)(rand() % 1000);
-                        vy = (float)(rand() % 1000);
-                        vw = (float)(rand() % 1000);
-                        vh = (float)(rand() % 1000);
+                        vx = (float)(XM_RAND() % 1000);
+                        vy = (float)(XM_RAND() % 1000);
+                        vw = (float)(XM_RAND() % 1000);
+                        vh = (float)(XM_RAND() % 1000);
                         nz = GetRandomFloat16();
                         xz = GetRandomFloat16();
                         pr = GetRandomMatrix4();
@@ -2428,8 +2428,8 @@ HRESULT Test245(LogProxy* pLog)
     int i,k;
     for(k = 0; k < 15; k++) {
         for(i = 0; i <4; i++) {
-            v1.v = XMVectorSetByIndex(v1,((float)rand()) / 2000.f - 8.f,i);
-            v2.v = XMVectorSetByIndex(v2,((float)rand()) / 2000.f - 8.f,i);
+            v1.v = XMVectorSetByIndex(v1,((float)XM_RAND()) / 2000.f - 8.f,i);
+            v2.v = XMVectorSetByIndex(v2,((float)XM_RAND()) / 2000.f - 8.f,i);
         }
         v1.v = XMVectorSetW(v1,_Q_NAN);
         v2.v = XMVectorSetW(v2,_Q_NAN);
@@ -2464,12 +2464,12 @@ HRESULT Test246(LogProxy* pLog)
     {
         for(k = 0; k < 15; k++) {
             for(i = 0; i <4; i++) {
-                v1.v = XMVectorSetByIndex(v1,((float)rand()) / 2000.f - 8.f,i);
-                v2.v = XMVectorSetByIndex(v2,((float)rand()) / 2000.f - 8.f,i);
+                v1.v = XMVectorSetByIndex(v1,((float)XM_RAND()) / 2000.f - 8.f,i);
+                v2.v = XMVectorSetByIndex(v2,((float)XM_RAND()) / 2000.f - 8.f,i);
             }
             v1.v = XMVectorSetW(v1,_Q_NAN);
             v2.v = XMVectorSetW(v2,_Q_NAN);
-            f = ((float)rand()) / 2000.f - 8.f;
+            f = ((float)XM_RAND()) / 2000.f - 8.f;
         // Result = RefractionIndex * Incident - Normal * (RefractionIndex * dot(Incident, Normal) + 
         // sqrt(1 - RefractionIndex * RefractionIndex * (1 - dot(Incident, Normal) * dot(Incident, Normal))))
             float dotIN = XMVectorGetX(v1) * XMVectorGetX(v2) + XMVectorGetY(v1) * XMVectorGetY(v2) + XMVectorGetZ(v1) * XMVectorGetZ(v2);
@@ -2497,9 +2497,9 @@ HRESULT Test246(LogProxy* pLog)
         XMVECTORF32 V = {1,1,1,1};
         for(k = 0; k < 15; k++) {
             for(i = 0; i <4; i++) {
-                v1.v = XMVectorSetByIndex(v1,((float)rand()) / 2000.f - 8.f,i);
-                v2.v = XMVectorSetByIndex(v2,((float)rand()) / 2000.f - 8.f,i);
-                V.v = XMVectorSetByIndex(V,std::max(((float)rand()) / 2000.f - 8.f, 0.f),i);
+                v1.v = XMVectorSetByIndex(v1,((float)XM_RAND()) / 2000.f - 8.f,i);
+                v2.v = XMVectorSetByIndex(v2,((float)XM_RAND()) / 2000.f - 8.f,i);
+                V.v = XMVectorSetByIndex(V,std::max(((float)XM_RAND()) / 2000.f - 8.f, 0.f),i);
             }
 
             v1.v = XMVectorSetW(v1,_Q_NAN);
@@ -2548,9 +2548,9 @@ HRESULT Test247(LogProxy* pLog)
         float tmp[4][4];
         for(int i = 0; i < 4; i++) {
             for(int j = 0; j < 4; j++) {
-                tmp[i][j] = ((float)rand())/2000.f - 8.f;
+                tmp[i][j] = ((float)XM_RAND())/2000.f - 8.f;
             }
-            v.v = XMVectorSetByIndex(v,((float)rand())/2000.f - 8.f,i);
+            v.v = XMVectorSetByIndex(v,((float)XM_RAND())/2000.f - 8.f,i);
         }
 #pragma warning( suppress : 6385 )
         XMMATRIX m( &tmp[0][0] );
@@ -2582,9 +2582,9 @@ HRESULT Test248(LogProxy* pLog)
         float tmp[4][4];
         for(int i = 0; i < 4; i++) {
             for(int j = 0; j < 4; j++) {
-                tmp[i][j] = ((float)rand())/2000.f - 8.f;
+                tmp[i][j] = ((float)XM_RAND())/2000.f - 8.f;
             }
-            v.v = XMVectorSetByIndex(v,((float)rand())/2000.f - 8.f,i);
+            v.v = XMVectorSetByIndex(v,((float)XM_RAND())/2000.f - 8.f,i);
         }
 #pragma warning( suppress : 6385 )
         XMMATRIX m( &tmp[0][0] );
@@ -2662,13 +2662,13 @@ HRESULT Test249(LogProxy* pLog)
                             //Fill up a matrix (m) with random junk.
                             for(int j = 0; j < 4; j++) 
                             {
-                                tmp[i][j] = ((float)rand())/2000.f - 8.f;
+                                tmp[i][j] = ((float)XM_RAND())/2000.f - 8.f;
                             }
                             
                             //Fill up all (dwNumItems) vectors (v) with stuff.
                             for(n = 0; n < dwNumItems; n++) 
                             {
-                                v[n] = XMVectorSetByIndex(v[n],((float)rand())/2000.f - 8.f,i);
+                                v[n] = XMVectorSetByIndex(v[n],((float)XM_RAND())/2000.f - 8.f,i);
                                 v[n] = XMVectorSetW(v[n],_Q_NAN);
                             }
                         }
@@ -2727,9 +2727,9 @@ HRESULT Test250(LogProxy* pLog)
         float tmp[4][4];
         for(int i = 0; i < 4; i++) {
             for(int j = 0; j < 4; j++) {
-                tmp[i][j] = ((float)rand())/2000.f - 8.f;
+                tmp[i][j] = ((float)XM_RAND())/2000.f - 8.f;
             }
-            v.v = XMVectorSetByIndex(v,((float)rand())/2000.f - 8.f,i);
+            v.v = XMVectorSetByIndex(v,((float)XM_RAND())/2000.f - 8.f,i);
         }
 #pragma warning( suppress : 6385 )
         XMMATRIX m( &tmp[0][0] );
@@ -2803,10 +2803,10 @@ HRESULT Test251(LogProxy* pLog)
                         float tmp[4][4];
                         for(int i = 0; i < 4; i++) {
                             for(int j = 0; j < 4; j++) {
-                                tmp[i][j] = ((float)rand())/2000.f - 8.f;
+                                tmp[i][j] = ((float)XM_RAND())/2000.f - 8.f;
                             }
                             for(n = 0; n < dwNumItems; n++) {
-                                v[n] = XMVectorSetByIndex(v[n],((float)rand())/2000.f - 8.f,i);
+                                v[n] = XMVectorSetByIndex(v[n],((float)XM_RAND())/2000.f - 8.f,i);
                                 v[n] = XMVectorSetW(v[n],_Q_NAN);
                             }
                         }
@@ -2915,13 +2915,13 @@ HRESULT Test252(LogProxy* pLog)
                             {
                                 for(int j = 0; j < 4; j++) 
                                 {
-                                    tmp[i][j] = ((float)rand())/2000.f - 8.f;
+                                    tmp[i][j] = ((float)XM_RAND())/2000.f - 8.f;
                                 }
                                 
                                 //Fill up all (dwNumItems) vectors (v) with stuff.
                                 for(n = 0; n < dwNumItems; n++) 
                                 {
-                                    v[n] = XMVectorSetByIndex(v[n],((float)rand())/2000.f - 8.f,i);
+                                    v[n] = XMVectorSetByIndex(v[n],((float)XM_RAND())/2000.f - 8.f,i);
                                     v[n] = XMVectorSetW(v[n],_Q_NAN);
                                 }
                             }
@@ -2997,10 +2997,10 @@ HRESULT Test253(LogProxy* pLog)
     XMMATRIX temp;
 
     for(int i = 0; i < 16; i++) {
-        vx = (float)(rand() % 1000);
-        vy = (float)(rand() % 1000);
-        vw = (float)(rand() % 1000);
-        vh = (float)(rand() % 1000);
+        vx = (float)(XM_RAND() % 1000);
+        vy = (float)(XM_RAND() % 1000);
+        vw = (float)(XM_RAND() % 1000);
+        vh = (float)(XM_RAND() % 1000);
         nz = GetRandomFloat16();
         xz = GetRandomFloat16();
         pr = GetRandomMatrix4();
@@ -3103,11 +3103,11 @@ HRESULT Test254(LogProxy* pLog)
                     for (OutStrideIndex=0; OutStrideIndex<countof(outs); OutStrideIndex++)
                     {
 
-                        i = rand() % 16;
-                        vx = (float)(rand() % 1000);
-                        vy = (float)(rand() % 1000);
-                        vw = (float)(rand() % 1000);
-                        vh = (float)(rand() % 1000);
+                        i = XM_RAND() % 16;
+                        vx = (float)(XM_RAND() % 1000);
+                        vy = (float)(XM_RAND() % 1000);
+                        vw = (float)(XM_RAND() % 1000);
+                        vh = (float)(XM_RAND() % 1000);
                         nz = GetRandomFloat16();
                         xz = GetRandomFloat16();
                         pr = GetRandomMatrix4();
@@ -3183,8 +3183,8 @@ HRESULT Test255(LogProxy* pLog)
     XMVECTORF32 v1={}, v2={};
     for(k = 0; k < 10; k++) {
         for(i = 0; i < 4; i++) {
-            v1.v = XMVectorSetByIndex(v1,((float)rand()) / 2000.f - 8.f,i);
-            v2.v = XMVectorSetByIndex(v2,((float)rand()) / 2000.f - 8.f,i);
+            v1.v = XMVectorSetByIndex(v1,((float)XM_RAND()) / 2000.f - 8.f,i);
+            v2.v = XMVectorSetByIndex(v2,((float)XM_RAND()) / 2000.f - 8.f,i);
         }
         v1.v = XMVector4Normalize(v1);
         v2.v = XMVector4Normalize(v2);
@@ -3213,8 +3213,8 @@ HRESULT Test256(LogProxy* pLog)
     XMVECTORF32 v1={}, v2={};
     for(k = 0; k < 10; k++) {
         for(i = 0; i < 4; i++) {
-            v1.v = XMVectorSetByIndex(v1,((float)rand()) / 2000.f - 8.f,i);
-            v2.v = XMVectorSetByIndex(v2,((float)rand()) / 2000.f - 8.f,i);
+            v1.v = XMVectorSetByIndex(v1,((float)XM_RAND()) / 2000.f - 8.f,i);
+            v2.v = XMVectorSetByIndex(v2,((float)XM_RAND()) / 2000.f - 8.f,i);
         }
         XMVECTOR check = XMVectorReplicate(acosf((XMVectorGetX(v1)*XMVectorGetX(v2)+XMVectorGetY(v1)*XMVectorGetY(v2)+XMVectorGetZ(v1)*XMVectorGetZ(v2)+XMVectorGetW(v1)*XMVectorGetW(v2))/(sqrtf((XMVectorGetX(v1)*XMVectorGetX(v1)+XMVectorGetY(v1)*XMVectorGetY(v1)+XMVectorGetZ(v1)*XMVectorGetZ(v1)+XMVectorGetW(v1)*XMVectorGetW(v1))*(XMVectorGetX(v2)*XMVectorGetX(v2)+XMVectorGetY(v2)*XMVectorGetY(v2)+XMVectorGetZ(v2)*XMVectorGetZ(v2)+XMVectorGetW(v2)*XMVectorGetW(v2))))));
         XMVECTOR r = XMVector4AngleBetweenVectors(v1,v2);
@@ -3301,9 +3301,9 @@ HRESULT Test258(LogProxy* pLog)
 
     for(k = 0; k <15; k++) {
         for(i = 0; i < 4; i++) {
-            v1.v = XMVectorSetByIndex(v1,((float)rand()) / 4000.f - 4.f,i);
-            v2.v = XMVectorSetByIndex(v2,((float)rand()) / 4000.f - 4.f,i);
-            v3.v = XMVectorSetByIndex(v3,((float)rand()) / 4000.f - 4.f,i);
+            v1.v = XMVectorSetByIndex(v1,((float)XM_RAND()) / 4000.f - 4.f,i);
+            v2.v = XMVectorSetByIndex(v2,((float)XM_RAND()) / 4000.f - 4.f,i);
+            v3.v = XMVectorSetByIndex(v3,((float)XM_RAND()) / 4000.f - 4.f,i);
         }
         FLOAT checkx =	XMVectorGetY(v1) * (XMVectorGetZ(v2) * XMVectorGetW(v3) - XMVectorGetZ(v3) * XMVectorGetW(v2)) -
                     XMVectorGetZ(v1) * (XMVectorGetY(v2) * XMVectorGetW(v3) - XMVectorGetY(v3) * XMVectorGetW(v2)) +
@@ -3362,8 +3362,8 @@ HRESULT Test259(LogProxy* pLog)
     int i, j;
     for(i = 0; i < 10; i++) {
         for(j = 0; j < 4; j++) {
-            l.v = XMVectorSetByIndex(l,((float)rand()) / 1000.f,j);
-            v.v = XMVectorSetByIndex(v,((float)rand()) / 1000.f,j);
+            l.v = XMVectorSetByIndex(l,((float)XM_RAND()) / 1000.f,j);
+            v.v = XMVectorSetByIndex(v,((float)XM_RAND()) / 1000.f,j);
         }
         XMVECTOR r = XMVector4Dot(l, v);
         XMVECTOR check = XMVectorReplicate(XMVectorGetX(l)*XMVectorGetX(v)+  XMVectorGetY(l)*XMVectorGetY(v)+  XMVectorGetZ(l)*XMVectorGetZ(v)+  XMVectorGetW(l)*XMVectorGetW(v));
@@ -3390,7 +3390,7 @@ HRESULT Test260(LogProxy* pLog)
     HRESULT ret = S_OK;
     for(j = 0; j < 16; j++) {
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -3406,7 +3406,7 @@ HRESULT Test260(LogProxy* pLog)
         }
         check = TRUE;
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -3431,7 +3431,7 @@ HRESULT Test261(LogProxy* pLog)
     HRESULT ret = S_OK;
     for(j = 0; j < 16; j++) {
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -3448,7 +3448,7 @@ HRESULT Test261(LogProxy* pLog)
 
         check = FALSE;
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -3473,7 +3473,7 @@ HRESULT Test262(LogProxy* pLog)
     HRESULT ret = S_OK;
     for(j = 0; j < 16; j++) {
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -3489,7 +3489,7 @@ HRESULT Test262(LogProxy* pLog)
         }
 
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -3641,7 +3641,7 @@ HRESULT Test267(LogProxy* pLog)
     HRESULT ret = S_OK;
     for(j = 0; j < 16; j++) {
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -3657,7 +3657,7 @@ HRESULT Test267(LogProxy* pLog)
         }
 
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -3683,7 +3683,7 @@ HRESULT Test268(LogProxy* pLog)
     HRESULT ret = S_OK;
     for(j = 0; j < 16; j++) {
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -3699,7 +3699,7 @@ HRESULT Test268(LogProxy* pLog)
         }
 
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -3726,8 +3726,8 @@ HRESULT Test269(LogProxy* pLog)
     for(j = 0; j < 16; j++) {
         for(k = 0; k < 2; k++) {
             for(i = 0; i < 4; i++) {
-                v1.v = XMVectorSetByIndex(v1,(float)(rand()) / 1000.f,i);
-                e.v = XMVectorSetByIndex(e,(float)(rand()) / 10000.f,i);
+                v1.v = XMVectorSetByIndex(v1,(float)(XM_RAND()) / 1000.f,i);
+                e.v = XMVectorSetByIndex(e,(float)(XM_RAND()) / 10000.f,i);
                 v2.v = XMVectorSetByIndex(v2,XMVectorGetByIndex(v1,i) + ((k & 1) ? 1 : -1) * ((j & (1 << i)) ? (XMVectorGetByIndex(e,i) + XMVectorGetByIndex(e,i)) : (XMVectorGetByIndex(e,i) / 2.f)),i);
             }
             check = ((j) ? FALSE : TRUE);
@@ -3864,7 +3864,7 @@ HRESULT Test271(LogProxy* pLog)
     HRESULT ret = S_OK;
     for(j = 0; j < 16; j++) {
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -3880,7 +3880,7 @@ HRESULT Test271(LogProxy* pLog)
         }
 
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -3962,8 +3962,8 @@ HRESULT Test274(LogProxy* pLog)
     int i,k;
     for(k = 0; k < 15; k++) {
         for(i = 0; i <4; i++) {
-            v1.v = XMVectorSetByIndex(v1,((float)rand()) / 2000.f - 8.f,i);
-            v2.v = XMVectorSetByIndex(v2,((float)rand()) / 2000.f - 8.f,i);
+            v1.v = XMVectorSetByIndex(v1,((float)XM_RAND()) / 2000.f - 8.f,i);
+            v2.v = XMVectorSetByIndex(v2,((float)XM_RAND()) / 2000.f - 8.f,i);
         }
         // Result = Incident - (2 * dot(Incident, Normal)) * Normal
         float dot = XMVectorGetX(v1) * XMVectorGetX(v2) + XMVectorGetY(v1) * XMVectorGetY(v2) + XMVectorGetZ(v1) * XMVectorGetZ(v2) + XMVectorGetW(v1) * XMVectorGetW(v2);
@@ -3995,10 +3995,10 @@ HRESULT Test275(LogProxy* pLog)
     //XMVector4Refract
     for(k = 0; k < 15; k++) {
         for(i = 0; i <4; i++) {
-            v1.v = XMVectorSetByIndex(v1,((float)rand()) / 2000.f - 8.f,i);
-            v2.v = XMVectorSetByIndex(v2,((float)rand()) / 2000.f - 8.f,i);
+            v1.v = XMVectorSetByIndex(v1,((float)XM_RAND()) / 2000.f - 8.f,i);
+            v2.v = XMVectorSetByIndex(v2,((float)XM_RAND()) / 2000.f - 8.f,i);
         }
-        f = ((float)rand()) / 2000.f - 8.f;
+        f = ((float)XM_RAND()) / 2000.f - 8.f;
     // Result = RefractionIndex * Incident - Normal * (RefractionIndex * dot(Incident, Normal) + 
     // sqrt(1 - RefractionIndex * RefractionIndex * (1 - dot(Incident, Normal) * dot(Incident, Normal))))
         float dot = XMVectorGetX(v1) * XMVectorGetX(v2) + XMVectorGetY(v1) * XMVectorGetY(v2) + XMVectorGetZ(v1) * XMVectorGetZ(v2) + XMVectorGetW(v1) * XMVectorGetW(v2);
@@ -4028,9 +4028,9 @@ HRESULT Test275(LogProxy* pLog)
     XMVECTORF32 V = {1,1,1,1};
     for(k = 0; k < 15; k++) {
         for(i = 0; i <4; i++) {
-            v1.v = XMVectorSetByIndex(v1,((float)rand()) / 2000.f - 8.f,i);
-            v2.v = XMVectorSetByIndex(v2,((float)rand()) / 2000.f - 8.f,i);
-            V.v = XMVectorSetByIndex(V,((float)rand()) / 2000.f - 8.f,i);
+            v1.v = XMVectorSetByIndex(v1,((float)XM_RAND()) / 2000.f - 8.f,i);
+            v2.v = XMVectorSetByIndex(v2,((float)XM_RAND()) / 2000.f - 8.f,i);
+            V.v = XMVectorSetByIndex(V,((float)XM_RAND()) / 2000.f - 8.f,i);
         }
 
     // Result = RefractionIndex * Incident - Normal * (RefractionIndex * dot(Incident, Normal) + 
@@ -4079,9 +4079,9 @@ HRESULT Test276(LogProxy* pLog)
         float tmp[4][4];
         for(int i = 0; i < 4; i++) {
             for(int j = 0; j < 4; j++) {
-                tmp[i][j] = ((float)rand())/2000.f - 8.f;
+                tmp[i][j] = ((float)XM_RAND())/2000.f - 8.f;
             }
-            v.v = XMVectorSetByIndex(v,((float)rand())/2000.f - 8.f,i);
+            v.v = XMVectorSetByIndex(v,((float)XM_RAND())/2000.f - 8.f,i);
         }
 #pragma warning( suppress : 6385 )
         XMMATRIX m( &tmp[0][0] );
@@ -4153,10 +4153,10 @@ HRESULT Test277(LogProxy* pLog)
                         float tmp[4][4];
                         for(int i = 0; i < 4; i++) {
                             for(int j = 0; j < 4; j++) {
-                                tmp[i][j] = ((float)rand())/2000.f - 8.f;
+                                tmp[i][j] = ((float)XM_RAND())/2000.f - 8.f;
                             }
                             for(n = 0; n < dwNumItems; n++) {
-                                v[n] = XMVectorSetByIndex(v[n],((float)rand())/2000.f - 8.f,i);
+                                v[n] = XMVectorSetByIndex(v[n],((float)XM_RAND())/2000.f - 8.f,i);
                             }
                         }
 #pragma warning( suppress : 6385 )
@@ -4208,8 +4208,8 @@ HRESULT Test442(LogProxy* pLog)
     XMVECTORF32 v1={}, v2={};
     for(k = 0; k < 10; k++) {
         for(i = 0; i < 4; i++) {
-            v1.v = XMVectorSetByIndex(v1,((float)rand()) / 2000.f - 8.f,i);
-            v2.v = XMVectorSetByIndex(v2,((float)rand()) / 2000.f - 8.f,i);
+            v1.v = XMVectorSetByIndex(v1,((float)XM_RAND()) / 2000.f - 8.f,i);
+            v2.v = XMVectorSetByIndex(v2,((float)XM_RAND()) / 2000.f - 8.f,i);
         }
         v1.v = XMVector2Normalize(v1);
         v2.v = XMVector2Normalize(v2);
@@ -4239,8 +4239,8 @@ HRESULT Test443(LogProxy* pLog)
     XMVECTORF32 v1={}, v2={};
     for(k = 0; k < 10; k++) {
         for(i = 0; i < 4; i++) {
-            v1.v = XMVectorSetByIndex(v1,((float)rand()) / 2000.f - 8.f,i);
-            v2.v = XMVectorSetByIndex(v2,((float)rand()) / 2000.f - 8.f,i);
+            v1.v = XMVectorSetByIndex(v1,((float)XM_RAND()) / 2000.f - 8.f,i);
+            v2.v = XMVectorSetByIndex(v2,((float)XM_RAND()) / 2000.f - 8.f,i);
         }
         v1.v = XMVector3Normalize(v1);
         v2.v = XMVector3Normalize(v2);
@@ -4270,8 +4270,8 @@ HRESULT Test444(LogProxy* pLog)
     XMVECTORF32 v1={}, v2={};
     for(k = 0; k < 10; k++) {
         for(i = 0; i < 4; i++) {
-            v1.v = XMVectorSetByIndex(v1,((float)rand()) / 2000.f - 8.f,i);
-            v2.v = XMVectorSetByIndex(v2,((float)rand()) / 2000.f - 8.f,i);
+            v1.v = XMVectorSetByIndex(v1,((float)XM_RAND()) / 2000.f - 8.f,i);
+            v2.v = XMVectorSetByIndex(v2,((float)XM_RAND()) / 2000.f - 8.f,i);
         }
         v1.v = XMVector4Normalize(v1);
         v2.v = XMVector4Normalize(v2);
@@ -4478,7 +4478,7 @@ HRESULT Test461(LogProxy* pLog)
     HRESULT ret = S_OK;
     for(j = 0; j < 16; j++) {
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -4494,7 +4494,7 @@ HRESULT Test461(LogProxy* pLog)
         }
         check = TRUE;
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -4519,7 +4519,7 @@ HRESULT Test462(LogProxy* pLog)
     HRESULT ret = S_OK;
     for(j = 0; j < 16; j++) {
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -4535,7 +4535,7 @@ HRESULT Test462(LogProxy* pLog)
         }
         check = FALSE;
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -4560,7 +4560,7 @@ HRESULT Test463(LogProxy* pLog)
     HRESULT ret = S_OK;
     for(j = 0; j < 16; j++) {
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -4576,7 +4576,7 @@ HRESULT Test463(LogProxy* pLog)
         }
         check = TRUE;
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -4601,7 +4601,7 @@ HRESULT Test464(LogProxy* pLog)
     HRESULT ret = S_OK;
     for(j = 0; j < 16; j++) {
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -4617,7 +4617,7 @@ HRESULT Test464(LogProxy* pLog)
         }
         check = FALSE;
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -4642,7 +4642,7 @@ HRESULT Test465(LogProxy* pLog)
     HRESULT ret = S_OK;
     for(j = 0; j < 16; j++) {
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -4658,7 +4658,7 @@ HRESULT Test465(LogProxy* pLog)
         }
         check = TRUE;
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -4683,7 +4683,7 @@ HRESULT Test466(LogProxy* pLog)
     HRESULT ret = S_OK;
     for(j = 0; j < 16; j++) {
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -4699,7 +4699,7 @@ HRESULT Test466(LogProxy* pLog)
         }
         check = FALSE;
         for(i = 0; i < 4; i++) {
-            float ftemp = (float)rand();
+            float ftemp = (float)XM_RAND();
             v1.v = XMVectorSetByIndex(v1,ftemp,i);
             v2.v = XMVectorSetByIndex(v2,ftemp,i);
         }
@@ -4743,7 +4743,7 @@ HRESULT Test473(LogProxy* pLog)
         pEntry = &TableZ[(i/36) /* %6 */];
         float v1z = pEntry->x;
         float v2z = pEntry->y;
-        pEntry = &TableW[rand()%6];
+        pEntry = &TableW[XM_RAND()%6];
         float v1w = pEntry->x;
         float v2w = pEntry->y;
         XMVECTOR v1 = XMVectorSet(v1x,v1y,v1z,v1w);
@@ -4789,7 +4789,7 @@ HRESULT Test474(LogProxy* pLog)
         pEntry = &TableZ[(i/64) /* &7 */];
         float v1z = pEntry->x;
         float v2z = pEntry->y;
-        pEntry = &TableW[rand()&7];
+        pEntry = &TableW[XM_RAND()&7];
         float v1w = pEntry->x;
         float v2w = pEntry->y;
         XMVECTOR v1 = XMVectorSet(v1x,v1y,v1z,v1w);
@@ -4837,7 +4837,7 @@ HRESULT Test475(LogProxy* pLog)
         pEntry = &TableZ[(i/36) /* %6 */];
         float v1z = pEntry->x;
         float v2z = pEntry->y;
-        pEntry = &TableW[rand()%6];
+        pEntry = &TableW[XM_RAND()%6];
         float v1w = pEntry->x;
         float v2w = pEntry->y;
         XMVECTOR v1 = XMVectorSet(v1x,v1y,v1z,v1w);
@@ -4885,7 +4885,7 @@ HRESULT Test476(LogProxy* pLog)
         pEntry = &TableZ[(i/36) /* %6 */];
         float v1z = pEntry->x;
         float v2z = pEntry->y;
-        pEntry = &TableW[rand()%6];
+        pEntry = &TableW[XM_RAND()%6];
         float v1w = pEntry->x;
         float v2w = pEntry->y;
         XMVECTOR v1 = XMVectorSet(v1x,v1y,v1z,v1w);
@@ -4932,7 +4932,7 @@ HRESULT Test477(LogProxy* pLog)
         pEntry = &TableZ[(i/64) /* &7 */];
         float v1z = pEntry->x;
         float v2z = pEntry->y;
-        pEntry = &TableW[rand()&7];
+        pEntry = &TableW[XM_RAND()&7];
         float v1w = pEntry->x;
         float v2w = pEntry->y;
         XMVECTOR v1 = XMVectorSet(v1x,v1y,v1z,v1w);
@@ -4976,7 +4976,7 @@ HRESULT Test479(LogProxy* pLog)
         pEntry = &TableZ[(i/36) /* %6 */];
         float v1z = pEntry->x;
         float v2z = pEntry->y;
-        pEntry = &TableW[rand()%6];
+        pEntry = &TableW[XM_RAND()%6];
         float v1w = pEntry->x;
         float v2w = pEntry->y;
         XMVECTOR v1 = XMVectorSet(v1x,v1y,v1z,v1w);
@@ -5022,7 +5022,7 @@ HRESULT Test480(LogProxy* pLog)
         pEntry = &TableZ[(i/64) /* &7 */];
         int v1z = pEntry->x;
         int v2z = pEntry->y;
-        pEntry = &TableW[rand()&7];
+        pEntry = &TableW[XM_RAND()&7];
         int v1w = pEntry->x;
         int v2w = pEntry->y;
         XMVECTOR v1 = XMVectorSetInt(v1x,v1y,v1z,v1w);
@@ -5068,7 +5068,7 @@ HRESULT Test481(LogProxy* pLog)
         pEntry = &TableZ[(i/36) /* %6 */];
         float v1z = pEntry->x;
         float v2z = pEntry->y;
-        pEntry = &TableW[rand()%6];
+        pEntry = &TableW[XM_RAND()%6];
         float v1w = pEntry->x;
         float v2w = pEntry->y;
         XMVECTOR v1 = XMVectorSet(v1x,v1y,v1z,v1w);
@@ -5114,7 +5114,7 @@ HRESULT Test482(LogProxy* pLog)
         pEntry = &TableZ[(i/36) /* %6 */];
         float v1z = pEntry->x;
         float v2z = pEntry->y;
-        pEntry = &TableW[rand()%6];
+        pEntry = &TableW[XM_RAND()%6];
         float v1w = pEntry->x;
         float v2w = pEntry->y;
         XMVECTOR v1 = XMVectorSet(v1x,v1y,v1z,v1w);
@@ -5160,7 +5160,7 @@ HRESULT Test483(LogProxy* pLog)
         pEntry = &TableZ[(i/64) /* &7 */];
         float v1z = pEntry->x;
         float v2z = pEntry->y;
-        pEntry = &TableW[rand()&7];
+        pEntry = &TableW[XM_RAND()&7];
         float v1w = pEntry->x;
         float v2w = pEntry->y;
         XMVECTOR v1 = XMVectorSet(v1x,v1y,v1z,v1w);
@@ -5204,7 +5204,7 @@ HRESULT Test485(LogProxy* pLog)
         pEntry = &TableZ[(i/36) /* %6 */];
         float v1z = pEntry->x;
         float v2z = pEntry->y;
-        pEntry = &TableW[rand()%6];
+        pEntry = &TableW[XM_RAND()%6];
         float v1w = pEntry->x;
         float v2w = pEntry->y;
         XMVECTOR v1 = XMVectorSet(v1x,v1y,v1z,v1w);
@@ -5250,7 +5250,7 @@ HRESULT Test486(LogProxy* pLog)
         pEntry = &TableZ[(i/64) /* &7 */];
         int v1z = pEntry->x;
         int v2z = pEntry->y;
-        pEntry = &TableW[rand()&7];
+        pEntry = &TableW[XM_RAND()&7];
         int v1w = pEntry->x;
         int v2w = pEntry->y;
         XMVECTOR v1 = XMVectorSetInt(v1x,v1y,v1z,v1w);
@@ -5297,7 +5297,7 @@ HRESULT Test487(LogProxy* pLog)
         pEntry = &TableZ[(i/36) /* %6 */];
         float v1z = pEntry->x;
         float v2z = pEntry->y;
-        pEntry = &TableW[rand()%6];
+        pEntry = &TableW[XM_RAND()%6];
         float v1w = pEntry->x;
         float v2w = pEntry->y;
         XMVECTOR v1 = XMVectorSet(v1x,v1y,v1z,v1w);
@@ -5343,7 +5343,7 @@ HRESULT Test488(LogProxy* pLog)
         pEntry = &TableZ[(i/36) /* %6 */];
         float v1z = pEntry->x;
         float v2z = pEntry->y;
-        pEntry = &TableW[rand()%6];
+        pEntry = &TableW[XM_RAND()%6];
         float v1w = pEntry->x;
         float v2w = pEntry->y;
         XMVECTOR v1 = XMVectorSet(v1x,v1y,v1z,v1w);
@@ -5390,7 +5390,7 @@ HRESULT Test489(LogProxy* pLog)
         pEntry = &TableZ[(i/64) /* &7 */];
         float v1z = pEntry->x;
         float v2z = pEntry->y;
-        pEntry = &TableW[rand()&7];
+        pEntry = &TableW[XM_RAND()&7];
         float v1w = pEntry->x;
         float v2w = pEntry->y;
         XMVECTOR v1 = XMVectorSet(v1x,v1y,v1z,v1w);

--- a/shmath/test.cpp
+++ b/shmath/test.cpp
@@ -1,3 +1,5 @@
+#include <cmath>
+
 #include <stdio.h>
 
 #pragma warning(disable : 4619 4616 4061 4265 4365 4514 4625 4668 4710 4711 4820 5039 5045)
@@ -14,6 +16,7 @@
 // C5039 pointer or reference to potentially throwing function passed to extern C function under - EHc
 // C5045 Spectre mitigation warning
 
+#ifdef _WIN32
 #include <d3d11_1.h>
 #pragma comment(lib,"d3d11.lib")
 #pragma comment(lib,"dxguid.lib")
@@ -24,9 +27,11 @@
 #pragma comment(lib,"d3d12.lib")
 #pragma comment(lib,"dxgi.lib")
 #endif
+#endif
 
 #include "DirectXSH.h"
 
+#ifdef _WIN32
 #include "DDSTextureLoader.h"
 
 #ifdef USE_DIRECT3D12
@@ -34,6 +39,7 @@
 #endif
 
 #include <wrl/client.h>
+#endif
 
 //#define GEN_RESULTS
 //#define TIMING
@@ -44,7 +50,11 @@
 
 using namespace DirectX;
 
+#ifdef _WIN32
 using Microsoft::WRL::ComPtr;
+#endif
+
+#include <stdarg.h>
 
 namespace
 {
@@ -86,6 +96,7 @@ bool fail = false;
 
 #define Fail() fail = true
 
+#ifdef _WIN32
 //---------------------------------------------------------------------------------
 class Timer
 {
@@ -151,6 +162,7 @@ HRESULT LoadCubemap( _In_ ID3D11Device* device, _In_z_ const WCHAR* filename, _O
 
     return S_OK;
 }
+#endif
 
 //-------------------------------------------------------------------------------------
 inline float Luminance(float r, float g, float b) {
@@ -184,16 +196,12 @@ public:
 //-------------------------------------------------------------------------------------
 bool Validatefloat(double d)
 {
-    switch( _fpclass(d) )
+    switch( std::fpclassify(d) )
     {
-    case _FPCLASS_NN:
-    case _FPCLASS_ND:
-    case _FPCLASS_NZ:
-    case _FPCLASS_PZ:
-    case _FPCLASS_PN:
-    case _FPCLASS_PD:
+    case FP_NORMAL:
+    case FP_SUBNORMAL:
+    case FP_ZERO:
         return true;
-
     default:
         return false;
     }
@@ -202,31 +210,14 @@ bool Validatefloat(double d)
 // returns string describing floating point class for d.
 const char *GetfloatClass(double d)
 {
-    switch( _fpclass(d) )
+    switch( std::fpclassify(d) )
     {
-    case _FPCLASS_SNAN:
-        return "signaling NaN";
-    case _FPCLASS_QNAN:
-        return "quiet NaN";
-    case _FPCLASS_NINF:
-        return "negative infinity";
-    case _FPCLASS_NN:
-        return "negative normal";
-    case _FPCLASS_ND:
-        return "negative denormal";
-    case _FPCLASS_NZ:
-        return "-0";
-    case _FPCLASS_PZ:
-        return "+0";
-    case _FPCLASS_PD:
-        return "positive denormal";
-    case _FPCLASS_PN:
-        return "positive normal";
-    case _FPCLASS_PINF:
-        return "positive infinity";
-
-    default:
-        return "no type listed float.h returned";
+        case FP_INFINITE:  return "Inf";
+        case FP_NAN:       return "NaN";
+        case FP_NORMAL:    return "normal";
+        case FP_SUBNORMAL: return "subnormal";
+        case FP_ZERO:      return "zero";
+        default: return "no type listed float.h returned";
     }
 }
 
@@ -237,7 +228,7 @@ bool Vrfy(float val1, float val2, float fTolerance, const char *fmt, ...)
     char msg[1024];
     va_list args;
     va_start(args, fmt);
-    _vsnprintf_s(msg, 1024, fmt, args);
+    vsnprintf(msg, 1024, fmt, args);
     va_end(args);    
 
     if(fabsf(val1 - val2) > fTolerance) {
@@ -302,7 +293,7 @@ void VerifySHVectors(_In_ size_t order, _In_reads_(order*order) const float *v1,
     for (l = 0; l < order; l++) {
         for (m = 0; m <= 2*l; m++) {
             char csDesc[1024];
-            sprintf_s(csDesc, "%s: sh[%zu]: expected value %f != %f", szMsgLabel, i, v1[i], v2[i]);
+            sprintf(csDesc, "%s: sh[%zu]: expected value %f != %f", szMsgLabel, i, v1[i], v2[i]);
             Vrfy(v1[i], v2[i], bandTolerances[l], csDesc);
             i++;
         }
@@ -327,7 +318,7 @@ void VerifySHVectors(_In_ size_t order, _In_reads_(order*order) const float *v1,
     // second ensure that the two results match within epsilon
     for (i = 0; i < order*order; i++) {
         char csDesc[1024];
-        sprintf_s(csDesc,  "ERROR: sh[%zu]: expected value %f != %f", i, v1[i], v2[i] );
+        sprintf(csDesc,  "ERROR: sh[%zu]: expected value %f != %f", i, v1[i], v2[i] );
         Vrfy(v1[i], v2[i], EPSILON, csDesc );
     }
 }
@@ -521,7 +512,7 @@ void Dot()
             e += shResultA[i] * shResultB[i];
 
         char csDesc[1024];
-        sprintf_s(csDesc, "ERROR: sh[%zu]: expected value %f != %f", order, e, r);
+        sprintf(csDesc, "ERROR: sh[%zu]: expected value %f != %f", order, e, r);
 
         Vrfy( r, e, EPSILON, csDesc );
     }
@@ -552,7 +543,9 @@ void EvalDirectionalLight()
         XMVECTOR clr = XMVectorSet(r, g, b, 0);
 
         XMVECTOR clr1 = XMVectorSet(1, 0, 0, 0);
+#ifdef TIMING
         g_timer.Start();
+#endif
         bool res = XMSHEvalDirectionalLight(order, z, clr1, shTmp0, nullptr, nullptr);
 #ifdef TIMING
         DWORD dur = g_timer.Stop();
@@ -651,7 +644,9 @@ void EvalSphericalLight()
         XMVECTOR tz = XMVectorScale( z, scale );
 
         XMVECTOR clr1 = XMVectorSet(1, 0, 0, 0);
+#ifdef TIMING
         g_timer.Start();
+#endif
         bool res = XMSHEvalSphericalLight(order, tz, radius, clr1, shTmp0, nullptr, nullptr);
 #ifdef TIMING
         DWORD dur = g_timer.Stop();
@@ -745,7 +740,9 @@ void EvalConeLight()
         const float radius = XM_PI/8.0f;
 
         XMVECTOR clr1 = XMVectorSet(1, 0, 0, 0);
+#ifdef TIMING
         g_timer.Start();
+#endif
         bool res = XMSHEvalConeLight(order, z, radius, clr1, shTmp0, nullptr, nullptr);
 #ifdef TIMING
         DWORD dur = g_timer.Stop();
@@ -838,7 +835,9 @@ void EvalHemisphereLight()
         InitResultData(shG);
         InitResultData(shB);
 
+#ifdef TIMING
         g_timer.Start();
+#endif
         bool res = XMSHEvalHemisphereLight(order, z, top, bot, shR, shG, shB );
 #ifdef TIMING
         DWORD dur = g_timer.Stop();
@@ -1044,7 +1043,9 @@ void Multiply()
         }
     
         // check return value and sanctity of inputs tests
+#ifdef TIMING
         g_timer.Start();
+#endif
         float* pOut = XMSHMultiply(shResultC, order, shResultA, shResultB);
 #ifdef TIMING
         DWORD dur = g_timer.Stop();
@@ -1120,7 +1121,7 @@ void Multiply()
                 }
                 CheckResultData(order,shInputA); CheckResultData(order,shInputB); CheckResultData(order,shResultC);
                 char csDesc[1024];
-                sprintf_s(csDesc, "XMSHMultiply C = A*B: Rotate(Y, Z) = (%f,%f)", theta.val, phi.val);
+                sprintf(csDesc, "XMSHMultiply C = A*B: Rotate(Y, Z) = (%f,%f)", theta.val, phi.val);
                 VerifySHVectors(order,shExpected, shResultC, g_bandTolerances[order-1], csDesc);
 
                 //
@@ -1131,7 +1132,7 @@ void Multiply()
                     Fail();
                 }
                 CheckResultData(order,shInputA); CheckResultData(order,shInputB); CheckResultData(order,shResultD);
-                sprintf_s(csDesc, "SHMultiply C = B*A == A*B: Rotate(Y, Z) = (%f,%f)", theta.val, phi.val);
+                sprintf(csDesc, "SHMultiply C = B*A == A*B: Rotate(Y, Z) = (%f,%f)", theta.val, phi.val);
                 VerifySHVectors(order,shResultC, shResultD, g_zeroTolerances, csDesc);
             }
         }
@@ -1165,6 +1166,7 @@ void dump_coeffs( _In_ FILE* f, _In_ size_t order, _In_reads_(order*order) const
 #include "coeff.cpp"
 #endif
 
+#ifdef _WIN32
 void ProjectCubeMap()
 {
     // Create Direct3D 11 Device
@@ -1413,7 +1415,7 @@ void ProjectCubeMap()
     }
 #endif
 }
-
+#endif
 
 #ifdef USE_DIRECT3D12
 void ProjectCubeMap12()
@@ -1584,7 +1586,10 @@ int main()
     EvalConeLight();
     EvalHemisphereLight();
     Multiply();
+
+#ifdef _WIN32
     ProjectCubeMap();
+#endif
 
 #ifdef USE_DIRECT3D12
     ProjectCubeMap12();

--- a/xdsp/Test.cpp
+++ b/xdsp/Test.cpp
@@ -11,6 +11,7 @@
 // C4820 padding added after data member
 // C5045 Spectre mitigation warning
 
+#include <cmath>
 #include <stdio.h>
 #include <float.h>
 #include <memory>
@@ -26,13 +27,13 @@ typedef DirectX::XMVECTORF32 XVEC;
 
 inline bool Compare(float a, float b)
 {
-    if (_isnan(a) && _isnan(b)) return true;
-    if (_isnan(a) || _isnan(b)) return false;
-    if (!_finite(a) && !_finite(b)) {
-        if (_copysign(1.0f, a) == _copysign(1.0f, b)) return true;
+    if (std::isnan(a) && std::isnan(b)) return true;
+    if (std::isnan(a) || std::isnan(b)) return false;
+    if (!std::isfinite(a) && !std::isfinite(b)) {
+        if (std::copysign(1.0f, a) == std::copysign(1.0f, b)) return true;
         else return false;
     }
-    if (!_finite(a) || !_finite(b)) return false;
+    if (!std::isfinite(a) || !std::isfinite(b)) return false;
 
     if (a == b) return true;
     float f = fabsf(b-a);
@@ -69,9 +70,14 @@ void print( const XVEC* a, size_t count )
     }
 }
 
+#ifdef _MSC_VER
+#define XM_ALIGNED_MALLOC(size,align) _aligned_malloc(size, align)
 struct aligned_deleter { void operator()(void* p) { _aligned_free(p); } };
-
 typedef std::unique_ptr<XVEC, aligned_deleter> ScopedAlignedArrayXVEC;
+#else
+#define XM_ALIGNED_MALLOC(size,align) std::aligned_alloc(align, size)
+typedef std::unique_ptr<XVEC> ScopedAlignedArrayXVEC;
+#endif
 
 //--------------------------------------------------------------------------------------
 bool FFT4Test()
@@ -184,7 +190,7 @@ bool FFTTest()
     XVEC iinput[] = { { { { 1.2f, 2.2f, 3.2f, 4.2f } } }, { { { 5.2f, 6.2f, 7.2f, 8.2f } } }, { { { 9.2f, 10.2f, 11.2f, 12.2f } } }, { { { 13.2f, 14.2f, 15.2f, 16.2f } } },
                       { { { 1.3f, 2.3f, 3.3f, 4.3f } } }, { { { 5.3f, 6.3f, 7.3f, 8.3f } } }, { { { 9.3f, 10.3f, 11.3f, 12.3f } } }, { { { 13.3f, 14.3f, 15.3f, 16.3f } } } };
 
-    ScopedAlignedArrayXVEC unity(reinterpret_cast<XVEC*>(_aligned_malloc( sizeof(XVEC) * 32, 16 ) ) );
+    ScopedAlignedArrayXVEC unity(reinterpret_cast<XVEC*>(XM_ALIGNED_MALLOC(sizeof(XVEC) * 32, 16) ) );
     FFTInitializeUnityTable(reinterpret_cast<XMVECTOR*>(unity.get()), 32 );
 
     FFT(reinterpret_cast<XMVECTOR*>(rinput), reinterpret_cast<XMVECTOR*>(iinput), reinterpret_cast<XMVECTOR*>(unity.get()), 32, 1 );
@@ -226,7 +232,7 @@ bool FFTUnswizzleTest()
 
     static const XVEC input[] = { { { { 0.f, 1.f, 2.f, 3.f } } },{ { { 4.f, 5.f, 6.f, 7.f } } },{ { { 8.f , 9.f, 10.f, 11.f } } },{ { { 12.f, 13.f, 14.f, 15.f } } } };
 
-    ScopedAlignedArrayXVEC output(reinterpret_cast<XVEC*>(_aligned_malloc(sizeof(XVEC) * 4, 16)));
+    ScopedAlignedArrayXVEC output(reinterpret_cast<XVEC*>(XM_ALIGNED_MALLOC(sizeof(XVEC) * 4, 16)));
 
     FFTUnswizzle(reinterpret_cast<XMVECTOR*>(output.get()), reinterpret_cast<const XMVECTOR*>(input), 4);
 
@@ -257,7 +263,7 @@ bool FFTPolarTest()
     XVEC iinput[] = { { { { 1.2f, 2.2f, 3.2f, 4.2f } } }, { { { 5.2f, 6.2f, 7.2f, 8.2f } } }, { { { 9.2f, 10.2f, 11.2f, 12.2f } } }, { { { 13.2f, 14.2f, 15.2f, 16.2f } } },
                       { { { 1.3f, 2.3f, 3.3f, 4.3f } } }, { { { 5.3f, 6.3f, 7.3f, 8.3f } } }, { { { 9.3f, 10.3f, 11.3f, 12.3f } } }, { { { 13.3f, 14.3f, 15.3f, 16.3f } } } };
 
-    ScopedAlignedArrayXVEC output(reinterpret_cast<XVEC*>(_aligned_malloc(sizeof(XVEC) * 8, 16)));
+    ScopedAlignedArrayXVEC output(reinterpret_cast<XVEC*>(XM_ALIGNED_MALLOC(sizeof(XVEC) * 8, 16)));
 
     FFTPolar(reinterpret_cast<XMVECTOR*>(output.get()), reinterpret_cast<XMVECTOR*>(rinput), reinterpret_cast<XMVECTOR*>(iinput), 32 );
 
@@ -286,7 +292,7 @@ bool DeinterleaveTest()
     static const XVEC input[] = { { { { 1.f, 2.f, 3.f, 4.f } } }, { { { 5.f, 6.f, 7.f, 8.f } } }, { { { 9.f, 10.f, 11.f, 12.f } } }, { { { 13.f, 14.f, 15.f, 16.f } } },
                                   { { { 1.1f, 2.1f, 3.1f, 4.1f } } }, { { { 5.1f, 6.1f, 7.1f, 8.1f } } }, { { { 9.1f, 10.1f, 11.1f, 12.1f } } }, { { { 13.1f, 14.1f, 15.1f, 16.1f } } } };
 
-    ScopedAlignedArrayXVEC output(reinterpret_cast<XVEC*>(_aligned_malloc(sizeof(XVEC) * 8, 16)));
+    ScopedAlignedArrayXVEC output(reinterpret_cast<XVEC*>(XM_ALIGNED_MALLOC(sizeof(XVEC) * 8, 16)));
 
     Deinterleave(reinterpret_cast<XMVECTOR*>(output.get()), reinterpret_cast<const XMVECTOR*>(input), 2, 16 );
         
@@ -313,7 +319,7 @@ bool InterleaveTest()
     static const XVEC input[] = { { { { 1.f, 2.f, 3.f, 4.f } } }, { { { 5.f, 6.f, 7.f, 8.f } } }, { { { 9.f, 10.f, 11.f, 12.f } } }, { { { 13.f, 14.f, 15.f, 16.f } } },
                                   { { { 1.1f, 2.1f, 3.1f, 4.1f } } }, { { { 5.1f, 6.1f, 7.1f, 8.1f } } }, { { { 9.1f, 10.1f, 11.1f, 12.1f } } }, { { { 13.1f, 14.1f, 15.1f, 16.1f } } } };
 
-    ScopedAlignedArrayXVEC output(reinterpret_cast<XVEC*>(_aligned_malloc(sizeof(XVEC) * 8, 16)));
+    ScopedAlignedArrayXVEC output(reinterpret_cast<XVEC*>(XM_ALIGNED_MALLOC(sizeof(XVEC) * 8, 16)));
 
     Interleave(reinterpret_cast<XMVECTOR*>(output.get()), reinterpret_cast<const XMVECTOR*>(input), 2, 16 );
         
@@ -349,7 +355,7 @@ bool FFTInterleavedTest()
                       { { { 1.7f, 2.7f, 3.7f, 4.7f } } }, { { { 5.7f, 6.7f, 7.7f, 8.7f } } }, { { { 9.7f, 10.7f, 11.7f, 12.7f } } }, { { { 13.7f, 14.7f, 15.7f, 16.7f } } }
     };
 
-    ScopedAlignedArrayXVEC unity(reinterpret_cast<XVEC*>(_aligned_malloc(sizeof(XVEC) * 32, 16)));
+    ScopedAlignedArrayXVEC unity(reinterpret_cast<XVEC*>(XM_ALIGNED_MALLOC(sizeof(XVEC) * 32, 16)));
     FFTInitializeUnityTable(reinterpret_cast<XMVECTOR*>(unity.get()), 32);
 
     FFTInterleaved(reinterpret_cast<XMVECTOR*>(rinput), reinterpret_cast<XMVECTOR*>(iinput), reinterpret_cast<XMVECTOR*>(unity.get()), 2, 5 );
@@ -423,7 +429,7 @@ bool IFFTDeinterleavedTest()
                       { { { 1.6f, 2.6f, 3.6f, 4.6f } } }, { { { 5.6f, 6.6f, 7.6f, 8.6f } } }, { { { 9.6f, 10.6f, 11.6f, 12.6f } } }, { { { 13.6f, 14.6f, 15.6f, 16.6f } } },
                       { { { 1.7f, 2.7f, 3.7f, 4.7f } } }, { { { 5.7f, 6.7f, 7.7f, 8.7f } } }, { { { 9.7f, 10.7f, 11.7f, 12.7f } } }, { { { 13.7f, 14.7f, 15.7f, 16.7f } } } };
        
-    ScopedAlignedArrayXVEC unity(reinterpret_cast<XVEC*>(_aligned_malloc(sizeof(XVEC) * 32, 16)));
+    ScopedAlignedArrayXVEC unity(reinterpret_cast<XVEC*>(XM_ALIGNED_MALLOC(sizeof(XVEC) * 32, 16)));
     FFTInitializeUnityTable(reinterpret_cast<XMVECTOR*>(unity.get()), 32);
 
     IFFTDeinterleaved(reinterpret_cast<XMVECTOR*>(rinput), reinterpret_cast<XMVECTOR*>(iinput), reinterpret_cast<XMVECTOR*>(unity.get()), 2, 5 );


### PR DESCRIPTION
* `cmake`: refactor and add GCC support
* `cpuid`: removed unneeded includes, fix cpuid call for GCC
* `ext`: removed `windows.h` include
* `math3`: fix include filenames casing
* `math3`: added lacking defines for non-Windows platforms
* `math3`: replace `rand()` with `XM_RAND()` which max values is limited with `0x8000` (glibc version generates values up to INT32_MAX, which causes test failures with GCC)
* `math3`, `shmath`: replace functions like `_fpclass` with `std::` alternatives
* `xdsp`: replace `_aligned_malloc` with `XM_ALIGNED_MALLOC`, which selects `_aligned_malloc` on MSVC and `std::aligned_alloc` on other toolsets

Requires https://github.com/microsoft/DirectXMath/pull/86


-----

Tested with
* Ubuntu 20.04
   - GCC 9
   - Clang 9
* Windows
  - MSVS 16.4.5
  - Clang-CL 9.0.0
