### PR TITLE
Fix tests under GCC and MinGW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ cmake_minimum_required (VERSION 3.12)
 
 project (directxmath LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-﻿# DirectXMath Test Suite
+# DirectXMath Test Suite
 #
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
@@ -44,7 +44,7 @@ if(MSVC)
 endif()
 
 if ( CMAKE_CXX_COMPILER_ID MATCHES "Clang" )
-    add_compile_options(/fp:fast "-Wall" "-Wpedantic" "-Wextra"
+    add_compile_options("-Wall" "-Wpedantic" "-Wextra"
        "-Wno-c++98-compat" "-Wno-c++98-compat-pedantic"
        "-Wno-gnu-anonymous-struct" "-Wno-nested-anon-types"
        "-Wno-float-equal" "-Wno-double-promotion"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ elseif ( CMAKE_CXX_COMPILER_ID MATCHES "MSVC" )
 endif()
 
 add_executable(cpuid cpuid/cpuid.cpp)
+target_compile_options(cpuid PRIVATE ${ARCH_AVX})
 
 add_executable(math3
     math3/box.cpp

--- a/math3/math3.cpp
+++ b/math3/math3.cpp
@@ -452,6 +452,23 @@ void ParseCommandLine(_In_z_ TCHAR* szCmdLine)
     }
 }
 
+#ifdef __linux__
+#include <linux/limits.h>
+TCHAR* GetCommandLine() {
+    char* cmdline = new char[ARG_MAX];
+    FILE *fp = fopen("/proc/self/cmdline", "r");
+    fgets(cmdline, ARG_MAX, fp);
+    fclose(fp);
+
+    for(int i = 0 ; i < ARG_MAX; i++){
+        if(cmdline[i]=='\0'){
+            if(cmdline[i+1] == '\0'){break;}
+            cmdline[i]=' ';
+        }
+    }
+    return cmdline;
+}
+#endif
 
 int __cdecl main(void)
 {

--- a/math3/math3.cpp
+++ b/math3/math3.cpp
@@ -377,17 +377,17 @@ void PrintCommandLineUsage()
 
 
 //Look for specific command line settings
-void ParseCommandLine(_In_z_ TCHAR* szCmdLine)
+void ParseCommandLine(_In_z_ wchar_t* szCmdLine)
 {
-    TCHAR* szArg = szCmdLine;
-    TCHAR* szValue = nullptr;
+    wchar_t* szArg = szCmdLine;
+    wchar_t* szValue = nullptr;
 
     //Command line valid?
     if (!szArg)
         return;
 
     //Get first argument with /
-    szArg = _tcschr(szArg, TEXT('/'));
+    szArg = wcschr(szArg, L'/');
 
     while (szArg)
     {
@@ -395,13 +395,13 @@ void ParseCommandLine(_In_z_ TCHAR* szCmdLine)
         szArg++;
 
         //Find value following argument
-        szValue = _tcschr(szArg, TEXT(' '));
+        szValue = wcschr(szArg, L' ');
 
         //Verify there is a value
-        if (szArg[0] != TEXT('?') && (!szValue || szValue[1] == TEXT('/')))
+        if (szArg[0] != L'?' && (!szValue || szValue[1] == L'/'))
         {
             //Try incrementing to the next argument and continuing
-            szArg = _tcschr(szArg, TEXT('/'));
+            szArg = wcschr(szArg, L'/');
             continue;
         }
 
@@ -410,37 +410,37 @@ void ParseCommandLine(_In_z_ TCHAR* szCmdLine)
             szValue++;
 
         //Test mode
-        if (!_tcsnicmp(szArg, TEXT("mode"), _tcslen(TEXT("mode"))))
+        if (!_wcsnicmp(szArg, L"mode", wcslen(L"mode")))
         {
             if (szValue)
             {
                 //Decipher the test mode
-                if (!_tcsnicmp(szValue, TEXT("normal"), _tcslen(TEXT("normal"))))
+                if (!_wcsnicmp(szValue, L"normal", wcslen(L"normal")))
                 {
                     gTestMode = TestModeNormal;
                 }
-                else if (!_tcsnicmp(szValue, TEXT("stress"), _tcslen(TEXT("stress"))))
+                else if (!_wcsnicmp(szValue, L"stress", wcslen(L"stress")))
                 {
                     gTestMode = TestModeStress;
                 }
             }
         }
-        else if (!_tcsnicmp(szArg, TEXT("breakonfail"), _tcslen(TEXT("breakonfail"))))
+        else if (!_wcsnicmp(szArg, L"breakonfail", wcslen(L"breakonfail")))
         {
             if (szValue)
             {
                 //break on fail setting
-                if (!_tcsnicmp(szValue, TEXT("true"), _tcslen(TEXT("true"))))
+                if (!_wcsnicmp(szValue, L"true", wcslen(L"true")))
                 {
                     gbBreakOnFail = true;
                 }
-                else if (!_tcsnicmp(szValue, TEXT("false"), _tcslen(TEXT("false"))))
+                else if (!_wcsnicmp(szValue, L"false", wcslen(L"false")))
                 {
                     gbBreakOnFail = false;
                 }
             }
         }
-        else if (!_tcsnicmp(szArg, TEXT("?"), _tcslen(TEXT("?"))))
+        else if (!_wcsnicmp(szArg, L"?", wcslen(L"?")))
         {
             //Usage
             PrintCommandLineUsage();
@@ -448,14 +448,16 @@ void ParseCommandLine(_In_z_ TCHAR* szCmdLine)
         }
 
         //Get next argument
-        szArg = _tcschr(szArg, TEXT('/'));
+        szArg = wcschr(szArg, L'/');
     }
 }
 
 #ifdef __linux__
 #include <linux/limits.h>
-TCHAR* GetCommandLine() {
+wchar_t* GetCommandLineW() {
     char* cmdline = new char[ARG_MAX];
+    wchar_t* cmdline_w = new wchar_t[ARG_MAX];
+
     FILE *fp = fopen("/proc/self/cmdline", "r");
     fgets(cmdline, ARG_MAX, fp);
     fclose(fp);
@@ -466,7 +468,11 @@ TCHAR* GetCommandLine() {
             cmdline[i]=' ';
         }
     }
-    return cmdline;
+
+    mbstowcs(cmdline_w, cmdline, ARG_MAX);
+    delete[] cmdline;
+
+    return cmdline_w;
 }
 #endif
 
@@ -475,7 +481,7 @@ int __cdecl main(void)
     //Get the command line to check for global test settings
     // usage of TCHAR is to maintain compatibility with 360
     // and GetCommandLine function.
-    TCHAR* cmdLine = GetCommandLine();
+    wchar_t* cmdLine = GetCommandLineW();
     ParseCommandLine(cmdLine);
 
     int result = 0;

--- a/math3/math3.h
+++ b/math3/math3.h
@@ -106,7 +106,6 @@
   #include <string.h>
 
   typedef long HRESULT;
-  typedef char TCHAR;
   typedef void* PVOID;
   typedef void* LPVOID;
   typedef int BOOL;
@@ -118,10 +117,8 @@
   #define FALSE (0)
   #define SUCCEEDED(hr) (((HRESULT)(hr)) >= 0)
   #define FAILED(hr) (((HRESULT)(hr)) < 0)
-  #define TEXT(x) (x)
-  #define _tcschr strchr
-  #define _tcsnicmp strncasecmp
-  #define _tcslen strlen
+
+  #define _wcsnicmp wcsncasecmp
 #endif
 #define print printf
 #define DATAPATH ""
@@ -308,10 +305,6 @@ struct APIFUNCT
 #include <iterator>
 #include <stdio.h>
 #include <stdlib.h>
-
-#ifdef _WIN32
-#include <tchar.h>
-#endif
 
 #include <DirectXMath.h>
 #include <DirectXColors.h>

--- a/math3/math3.h
+++ b/math3/math3.h
@@ -99,7 +99,30 @@
 #define NOMCX
 #pragma warning(pop)
 
+#ifdef _WIN32
 #include <Windows.h>
+#else
+  #include <cstdint>
+  #include <string.h>
+
+  typedef long HRESULT;
+  typedef char TCHAR;
+  typedef void* PVOID;
+  typedef void* LPVOID;
+  typedef int BOOL;
+  typedef float FLOAT;
+
+  #define S_OK (0)
+  #define E_FAIL (0x80004005)
+  #define TRUE (1)
+  #define FALSE (0)
+  #define SUCCEEDED(hr) (((HRESULT)(hr)) >= 0)
+  #define FAILED(hr) (((HRESULT)(hr)) < 0)
+  #define TEXT(x) (x)
+  #define _tcschr strchr
+  #define _tcsnicmp strncasecmp
+  #define _tcslen strlen
+#endif
 #define print printf
 #define DATAPATH ""
 static const int XB = 0;
@@ -139,6 +162,12 @@ static const int PC = 0;
 //make random behaviour identical for all the compilers
 #define XM_RAND_MAX (0x7fff)
 #define XM_RAND() (rand()%(XM_RAND_MAX+1))
+
+//calling conventions for GCC
+#if defined(__GNUC__) && !defined(__MINGW32__)
+#define __cdecl __attribute__((__cdecl__))
+#define __stdcall __attribute__((stdcall))
+#endif
 
 //crossplatform aligned malloc
 #if defined(_WIN32)
@@ -280,7 +309,9 @@ struct APIFUNCT
 #include <stdio.h>
 #include <stdlib.h>
 
+#ifdef _WIN32
 #include <tchar.h>
+#endif
 
 #include <DirectXMath.h>
 #include <DirectXColors.h>
@@ -298,11 +329,10 @@ struct APIFUNCT
 
 using XMVECTORI = DirectX::XMVECTORU32;
 
-#ifndef __MINGW32__
+#if defined(_WIN32) && !defined(__MINGW32__)
 #include <intrin.h>
 #endif
 
-#include <algorithm>
 #include <cmath>
 
 //extern "C" { extern HRESULT __stdcall MapDrive(char cDriveLetter, char* pszPartition); }

--- a/math3/math3.h
+++ b/math3/math3.h
@@ -140,6 +140,15 @@ static const int PC = 0;
 #define XM_RAND_MAX (0x7fff)
 #define XM_RAND() (rand()%(XM_RAND_MAX+1))
 
+//crossplatform aligned malloc
+#if defined(_WIN32)
+#define XM_ALIGNED_MALLOC(size,align) _aligned_malloc(size, align)
+#define XM_ALIGNED_FREE(p) _aligned_free(p)
+#else
+#define XM_ALIGNED_MALLOC(size,align) std::aligned_alloc(align, size)
+#define XM_ALIGNED_FREE(p) free(p)
+#endif
+
 #ifdef BUILD_FOR_HARNESS
 #include "h2.h"
 

--- a/math3/math3.h
+++ b/math3/math3.h
@@ -267,6 +267,7 @@ struct APIFUNCT
     const char* name;
 };
 
+#include <iterator>
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/math3/math3.h
+++ b/math3/math3.h
@@ -302,6 +302,7 @@ struct APIFUNCT
     const char* name;
 };
 
+#include <algorithm>
 #include <iterator>
 #include <stdio.h>
 #include <stdlib.h>

--- a/math3/math3tests.cpp
+++ b/math3/math3tests.cpp
@@ -1108,7 +1108,7 @@ HRESULT Test069(LogProxy* pLog)
     }
 
     int32_t sint[] = { 1, 1, 0, 0, -1, -1, 0x7FFFFFFF, int32_t(0xFFFFFFFF) };
-    for (i = 0; i < _countof(sint) / intcount; ++i)
+    for (i = 0; i < std::size(sint) / intcount; ++i)
     {
         XMVECTOR v = XMLoadSInt2((const XMINT2*)&sint[i * intcount]);
 
@@ -1124,7 +1124,7 @@ HRESULT Test069(LogProxy* pLog)
     }
 
     uint32_t uint[] = { 1, 1, 0, 0, 0x0340c0f0, 0x82e02304, 0x7FFFFFFF, 0xFFFFFFFF };
-    for (i = 0; i < _countof(uint) / intcount; ++i)
+    for (i = 0; i < std::size(uint) / intcount; ++i)
     {
         XMVECTOR v = XMLoadUInt2((const XMUINT2*)&uint[i * intcount]);
 
@@ -1364,7 +1364,7 @@ HRESULT Test071(LogProxy* pLog)
     }
 
     int32_t sint[] = { 1, 1, 1, 0, 0, 0, -1, -1, -1, 0x7FFFFFFF, int32_t(0xFFFFFFFF), 0x1F1F1F1F };
-    for (i = 0; i < _countof(sint) / intcount; ++i)
+    for (i = 0; i < std::size(sint) / intcount; ++i)
     {
         XMVECTOR v = XMLoadSInt3((const XMINT3*)&sint[i * intcount]);
 
@@ -1381,7 +1381,7 @@ HRESULT Test071(LogProxy* pLog)
     }
 
     uint32_t uint[] = { 1, 1, 1, 0, 0, 0, 0x0340c0f0, 0x82e02304, 0x4839efcd, 0x7FFFFFFF, 0xFFFFFFFF, 0x1F1F1F1F };
-    for (i = 0; i < _countof(uint) / intcount; ++i)
+    for (i = 0; i < std::size(uint) / intcount; ++i)
     {
         XMVECTOR v = XMLoadUInt3((const XMUINT3*)&uint[i * intcount]);
 
@@ -1696,7 +1696,7 @@ HRESULT Test074(LogProxy* pLog)
     }
 
     int32_t sint[] = { 1, 1, 1, 1, 0, 0, 0, 0, -1, -1, -1, -1, 0x7FFFFFFF, int32_t(0xFFFFFFFF), 0x1F1F1F1F, int32_t(0xCDCDCDCD) };
-    for (i = 0; i < _countof(sint) / intcount; ++i)
+    for (i = 0; i < std::size(sint) / intcount; ++i)
     {
         v = XMLoadSInt4((const XMINT4*)&sint[i * intcount]);
 
@@ -1713,7 +1713,7 @@ HRESULT Test074(LogProxy* pLog)
     }
 
     uint32_t uint[] = { 1, 1, 1, 1, 0, 0, 0, 0, 0x0340c0f0, 0x82e02304, 0x4839efcd, 0x838df7cd, 0x7FFFFFFF, 0xFFFFFFFF, 0x1F1F1F1F, 0xCDCDCDCD };
-    for (i = 0; i < _countof(uint) / intcount; ++i)
+    for (i = 0; i < std::size(uint) / intcount; ++i)
     {
         v = XMLoadUInt4((const XMUINT4*)&uint[i * intcount]);
 
@@ -3825,7 +3825,7 @@ HRESULT Test178(LogProxy* pLog)
 
     static const XMVECTORF32 vsint[] = { { 1.f, 1.f, _Q_NAN, _Q_NAN }, { 0.f, 0.f, _Q_NAN, _Q_NAN }, { -1.f, -1.f, _Q_NAN, _Q_NAN }, { 2147483392.f, -1.f, _Q_NAN, _Q_NAN } };
     int32_t sint[] = { 1, 1, 0, 0, -1, -1, 0x7FFFFF00, -1 };
-    for (i = 0; i < _countof(vsint); ++i)
+    for (i = 0; i < std::size(vsint); ++i)
     {
         XMINT2 x;
         XMStoreSInt2(&x, vsint[i]);
@@ -3841,7 +3841,7 @@ HRESULT Test178(LogProxy* pLog)
 
     static const XMVECTORF32 vuint[] = { { 1.f, 1.f, 1.f, 1.f }, { 0.f, 0.f, 0.f, 0.f }, { 54575344.f, 2195727104.f, 1211756544.f, 2207119360.f }, { 2147483392.f, 4294967040.f, 134217728.f, 522133280.f } };
     uint32_t uint[] = { 1, 1, 0, 0, 0x0340c0f0, 0x82e02300, 0x7FFFFF00, 0xFFFFFF00 };
-    for (i = 0; i < _countof(vuint); ++i)
+    for (i = 0; i < std::size(vuint); ++i)
     {
         XMUINT2 x;
         XMStoreUInt2(&x, vuint[i]);
@@ -4030,7 +4030,7 @@ HRESULT Test180(LogProxy* pLog)
 
     static const XMVECTORF32 vsint[] = { { 1.f, 1.f, 1.f, _Q_NAN }, { 0.f, 0.f, 0.f, _Q_NAN }, { -1.f, -1.f, -1.f, _Q_NAN }, { 2147483392.f, -1.f, 134217728.f, _Q_NAN } };
     int32_t sint[] = { 1, 1, 1, 0, 0, 0, -1, -1, -1, 0x7FFFFF00, -1, 0x8000000 };
-    for (i = 0; i < _countof(vsint); ++i)
+    for (i = 0; i < std::size(vsint); ++i)
     {
         XMINT3 x;
         XMStoreSInt3(&x, vsint[i]);
@@ -4048,7 +4048,7 @@ HRESULT Test180(LogProxy* pLog)
 
     static const XMVECTORF32 vuint[] = { { 1.f, 1.f, 1.f, _Q_NAN }, { 0.f, 0.f, 0.f, _Q_NAN }, { 54575344.f, 2195727104.f, 1211756544.f, _Q_NAN }, { 2147483392.f, 4294967040.f, 134217728.f, _Q_NAN } };
     static uint32_t uint[] = { 1, 1, 1, 0, 0, 0, 0x0340c0f0, 0x82e02300, 0x4839f000, 0x7FFFFF00, 0xFFFFFF00, 0x8000000 };
-    for (i = 0; i < _countof(vuint); ++i)
+    for (i = 0; i < std::size(vuint); ++i)
     {
         XMUINT3 x;
         XMStoreUInt3(&x, vuint[i]);
@@ -4260,7 +4260,7 @@ HRESULT Test183(LogProxy* pLog)
 
     static const XMVECTORF32 vsint[] = { { 1.f, 1.f, 1.f, 1.f }, { 0.f, 0.f, 0.f, 0.f }, { -1.f, -1.f, -1.f, -1.f }, { 2147483392.f, -1.f, 134217728.f, 522133280.f } };
     int32_t sint[] = { 1, 1, 1, 1, 0, 0, 0, 0, -1, -1, -1, -1, 0x7FFFFF00, -1, 0x8000000, 0x1F1F1F20 };
-    for (i = 0; i < _countof(vsint); ++i)
+    for (i = 0; i < std::size(vsint); ++i)
     {
         XMINT4 x;
         XMStoreSInt4(&x, vsint[i]);
@@ -4279,7 +4279,7 @@ HRESULT Test183(LogProxy* pLog)
 
     static const XMVECTORF32 vuint[] = { { 1.f, 1.f, 1.f, 1.f }, { 0.f, 0.f, 0.f, 0.f }, { 54575344.f, 2195727104.f, 1211756544.f, 2207119360.f }, { 2147483392.f, 4294967040.f, 134217728.f, 522133280.f } };
     uint32_t uint[] = { 1, 1, 1, 1, 0, 0, 0, 0, 0x0340c0f0, 0x82e02300, 0x4839f000, 0x838df800, 0x7FFFFF00, 0xFFFFFF00, 0x8000000, 0x1F1F1F20 };
-    for (i = 0; i < _countof(vuint); ++i)
+    for (i = 0; i < std::size(vuint); ++i)
     {
         XMUINT4 x;
         XMStoreUInt4(&x, vuint[i]);
@@ -7908,7 +7908,7 @@ HRESULT Test590(LogProxy* pLog)
                             {1.f, 2.f, 3.f, 1.f},
                             {32.f, 480.f, 2016.f, 1.f} };
 
-    static_assert(_countof(s) == _countof(check), "bad test");
+    static_assert(std::size(s) == std::size(check), "bad test");
 
     for (int k = 0; k < countof(s); k++)
     {
@@ -7963,12 +7963,12 @@ HRESULT Test591(LogProxy* pLog)
                         {1.f, 2.f, 3.f, 1.f},
                         {32.f, 480.f, 2016.f, 1.f} };
 
-    static_assert(_countof(v) == _countof(check), "bad test");
+    static_assert(std::size(v) == std::size(check), "bad test");
 
     int n = 0;
     for (j = pc64k - 64; j <= pc64k + 64; j += 4)
     {
-        n = (n + 1) % (_countof(check));
+        n = (n + 1) % (std::size(check));
         for (i = 0; i < csize; i++)
         {
             c[i] = (char)(~i & 0xff);

--- a/math3/shared.cpp
+++ b/math3/shared.cpp
@@ -156,7 +156,7 @@ void AllocWithAlignment(
     LPVOID* ppvUseThisOne    //Use this pointer, it has the alignment (and of course attributes) you requested.
 )
 {
-    void* pMemory = _aligned_malloc(dwSize + 16, dwAlignment);
+    void* pMemory = XM_ALIGNED_MALLOC(dwSize + 16, dwAlignment);
     if (pMemory)
     {
         *ppvFreeThisOne = pMemory;
@@ -186,7 +186,7 @@ void FreeWithAlignment(PVOID pAddress, uint32_t /*dwAllocAttributes*/)
 {
     if (pAddress)
     {
-        _aligned_free(pAddress);
+        XM_ALIGNED_FREE(pAddress);
     }
 }
 

--- a/math3/xmvec.cpp
+++ b/math3/xmvec.cpp
@@ -186,7 +186,7 @@ HRESULT Test281(LogProxy* pLog)
         {.125,.25,-.75,1000},  {-.3125,0,90,-2},  {-.1875,.25,89.25,998},
         {.1f,.2f,.3f,.4f},  {.5f,.6f,.7f,.8f},  {.6f,.8f,1,1.2f}
     };
-    for (int i = 0; i < _countof(f); i += 3) {
+    for (int i = 0; i < std::size(f); i += 3) {
         XMVECTOR v1 = f[i];
         XMVECTOR v2 = f[i + 1];
         XMVECTOR check = f[i + 2];
@@ -249,7 +249,7 @@ HRESULT Test296(LogProxy* pLog)
         { .6f,.8f,1,1.2f },{ 3.6f,3.6f,3.6f,3.6f }
     };
 
-    for (int i = 0; i < _countof(f); i += 2) {
+    for (int i = 0; i < std::size(f); i += 2) {
         XMVECTOR v = f[i];
         XMVECTOR check = f[i + 1];
         XMVECTOR r = XMVectorSum(v);
@@ -944,7 +944,7 @@ HRESULT Test291(LogProxy* pLog)
         { _Q_NAN, _Q_NAN, _Q_NAN, _Q_NAN}, { _Q_NAN, _Q_NAN, _Q_NAN, _Q_NAN},
     };
 
-    for (size_t i = 0; i < _countof(f); i += 2) {
+    for(size_t i = 0; i < std::size(f); i += 2) {
         XMVECTOR v1 = f[i];
         XMVECTOR check = f[i + 1];
         XMVECTOR r = XMVectorCeiling(v1);
@@ -1322,7 +1322,7 @@ HRESULT Test300(LogProxy* pLog)
         { _Q_NAN, _Q_NAN, _Q_NAN, _Q_NAN}, { _Q_NAN, _Q_NAN, _Q_NAN, _Q_NAN},
     };
 
-    for (size_t i = 0; i < _countof(f); i += 2) {
+    for(size_t i = 0; i < std::size(f); i += 2) {
         XMVECTOR v1 = f[i];
         XMVECTOR check = f[i + 1];
         XMVECTOR r = XMVectorFloor(v1);
@@ -2753,7 +2753,7 @@ HRESULT Test328(LogProxy* pLog)
         {  -_INF,  -_INF,  -_INF,  -_INF}, {  -_INF,  -_INF,  -_INF,  -_INF},
         { _Q_NAN, _Q_NAN, _Q_NAN, _Q_NAN}, { _Q_NAN, _Q_NAN, _Q_NAN, _Q_NAN},
     };
-    for (size_t i = 0; i < _countof(f); i += 2) {
+    for(size_t i = 0; i < std::size(f); i += 2) {
         XMVECTOR v1 = f[i];
         XMVECTOR check = f[i + 1];
         XMVECTOR r = XMVectorRound(v1);
@@ -3684,7 +3684,7 @@ HRESULT Test352(LogProxy* pLog)
         { _Q_NAN, _Q_NAN, _Q_NAN, _Q_NAN}, { _Q_NAN, _Q_NAN, _Q_NAN, _Q_NAN},
     };
 
-    for (size_t i = 0; i < _countof(f); i += 2) {
+    for(size_t i = 0; i < std::size(f); i += 2) {
         XMVECTOR v1 = f[i];
         XMVECTOR check = f[i + 1];
         XMVECTOR r = XMVectorTruncate(v1);

--- a/shmath/test.cpp
+++ b/shmath/test.cpp
@@ -62,6 +62,11 @@ using Microsoft::WRL::ComPtr;
 #pragma warning(disable:4189)
 #endif
 
+#ifndef _WIN32
+#define sprintf_s(a,b,...) sprintf(a,b,__VA_ARGS__)
+#define _vsnprintf_s(a,b,...)  vsnprintf(a,b,__VA_ARGS__)
+#endif
+
 using namespace DirectX;
 
 namespace

--- a/xdsp/Test.cpp
+++ b/xdsp/Test.cpp
@@ -18,6 +18,8 @@
 // C4820 padding added after data member
 // C5045 Spectre mitigation warning
 
+#include <memory>
+
 #include "XDSP.h"
 
 #include <stdio.h>
@@ -25,7 +27,6 @@
 #include <malloc.h>
 
 #include <cmath>
-#include <memory>
 
 //--------------------------------------------------------------------------------------
 typedef DirectX::XMVECTOR XVECTOR;

--- a/xdsp/Test.cpp
+++ b/xdsp/Test.cpp
@@ -78,8 +78,16 @@ void print( const XVEC* a, size_t count )
     }
 }
 
-struct aligned_deleter { void operator()(void* p) { _aligned_free(p); } };
+//crossplatform aligned malloc
+#if defined(_WIN32)
+#define XM_ALIGNED_MALLOC(size,align) _aligned_malloc(size, align)
+#define XM_ALIGNED_FREE(p) _aligned_free(p)
+#else
+#define XM_ALIGNED_MALLOC(size,align) std::aligned_alloc(align, size)
+#define XM_ALIGNED_FREE(p) free(p)
+#endif
 
+struct aligned_deleter { void operator()(void* p) { XM_ALIGNED_FREE(p); } };
 typedef std::unique_ptr<XVEC, aligned_deleter> ScopedAlignedArrayXVEC;
 
 //--------------------------------------------------------------------------------------
@@ -193,7 +201,7 @@ bool FFTTest()
     XVEC iinput[] = { { { { 1.2f, 2.2f, 3.2f, 4.2f } } }, { { { 5.2f, 6.2f, 7.2f, 8.2f } } }, { { { 9.2f, 10.2f, 11.2f, 12.2f } } }, { { { 13.2f, 14.2f, 15.2f, 16.2f } } },
                       { { { 1.3f, 2.3f, 3.3f, 4.3f } } }, { { { 5.3f, 6.3f, 7.3f, 8.3f } } }, { { { 9.3f, 10.3f, 11.3f, 12.3f } } }, { { { 13.3f, 14.3f, 15.3f, 16.3f } } } };
 
-    ScopedAlignedArrayXVEC unity(reinterpret_cast<XVEC*>(_aligned_malloc( sizeof(XVEC) * 32, 16 ) ) );
+    ScopedAlignedArrayXVEC unity(reinterpret_cast<XVEC*>(XM_ALIGNED_MALLOC(sizeof(XVEC) * 32, 16) ) );
     FFTInitializeUnityTable(reinterpret_cast<XMVECTOR*>(unity.get()), 32 );
 
     FFT(reinterpret_cast<XMVECTOR*>(rinput), reinterpret_cast<XMVECTOR*>(iinput), reinterpret_cast<XMVECTOR*>(unity.get()), 32, 1 );
@@ -235,7 +243,7 @@ bool FFTUnswizzleTest()
 
     static const XVEC input[] = { { { { 0.f, 1.f, 2.f, 3.f } } },{ { { 4.f, 5.f, 6.f, 7.f } } },{ { { 8.f , 9.f, 10.f, 11.f } } },{ { { 12.f, 13.f, 14.f, 15.f } } } };
 
-    ScopedAlignedArrayXVEC output(reinterpret_cast<XVEC*>(_aligned_malloc(sizeof(XVEC) * 4, 16)));
+    ScopedAlignedArrayXVEC output(reinterpret_cast<XVEC*>(XM_ALIGNED_MALLOC(sizeof(XVEC) * 4, 16)));
 
     FFTUnswizzle(reinterpret_cast<XMVECTOR*>(output.get()), reinterpret_cast<const XMVECTOR*>(input), 4);
 
@@ -266,7 +274,7 @@ bool FFTPolarTest()
     XVEC iinput[] = { { { { 1.2f, 2.2f, 3.2f, 4.2f } } }, { { { 5.2f, 6.2f, 7.2f, 8.2f } } }, { { { 9.2f, 10.2f, 11.2f, 12.2f } } }, { { { 13.2f, 14.2f, 15.2f, 16.2f } } },
                       { { { 1.3f, 2.3f, 3.3f, 4.3f } } }, { { { 5.3f, 6.3f, 7.3f, 8.3f } } }, { { { 9.3f, 10.3f, 11.3f, 12.3f } } }, { { { 13.3f, 14.3f, 15.3f, 16.3f } } } };
 
-    ScopedAlignedArrayXVEC output(reinterpret_cast<XVEC*>(_aligned_malloc(sizeof(XVEC) * 8, 16)));
+    ScopedAlignedArrayXVEC output(reinterpret_cast<XVEC*>(XM_ALIGNED_MALLOC(sizeof(XVEC) * 8, 16)));
 
     FFTPolar(reinterpret_cast<XMVECTOR*>(output.get()), reinterpret_cast<XMVECTOR*>(rinput), reinterpret_cast<XMVECTOR*>(iinput), 32 );
 
@@ -295,7 +303,7 @@ bool DeinterleaveTest()
     static const XVEC input[] = { { { { 1.f, 2.f, 3.f, 4.f } } }, { { { 5.f, 6.f, 7.f, 8.f } } }, { { { 9.f, 10.f, 11.f, 12.f } } }, { { { 13.f, 14.f, 15.f, 16.f } } },
                                   { { { 1.1f, 2.1f, 3.1f, 4.1f } } }, { { { 5.1f, 6.1f, 7.1f, 8.1f } } }, { { { 9.1f, 10.1f, 11.1f, 12.1f } } }, { { { 13.1f, 14.1f, 15.1f, 16.1f } } } };
 
-    ScopedAlignedArrayXVEC output(reinterpret_cast<XVEC*>(_aligned_malloc(sizeof(XVEC) * 8, 16)));
+    ScopedAlignedArrayXVEC output(reinterpret_cast<XVEC*>(XM_ALIGNED_MALLOC(sizeof(XVEC) * 8, 16)));
 
     Deinterleave(reinterpret_cast<XMVECTOR*>(output.get()), reinterpret_cast<const XMVECTOR*>(input), 2, 16 );
         
@@ -322,7 +330,7 @@ bool InterleaveTest()
     static const XVEC input[] = { { { { 1.f, 2.f, 3.f, 4.f } } }, { { { 5.f, 6.f, 7.f, 8.f } } }, { { { 9.f, 10.f, 11.f, 12.f } } }, { { { 13.f, 14.f, 15.f, 16.f } } },
                                   { { { 1.1f, 2.1f, 3.1f, 4.1f } } }, { { { 5.1f, 6.1f, 7.1f, 8.1f } } }, { { { 9.1f, 10.1f, 11.1f, 12.1f } } }, { { { 13.1f, 14.1f, 15.1f, 16.1f } } } };
 
-    ScopedAlignedArrayXVEC output(reinterpret_cast<XVEC*>(_aligned_malloc(sizeof(XVEC) * 8, 16)));
+    ScopedAlignedArrayXVEC output(reinterpret_cast<XVEC*>(XM_ALIGNED_MALLOC(sizeof(XVEC) * 8, 16)));
 
     Interleave(reinterpret_cast<XMVECTOR*>(output.get()), reinterpret_cast<const XMVECTOR*>(input), 2, 16 );
         
@@ -358,7 +366,7 @@ bool FFTInterleavedTest()
                       { { { 1.7f, 2.7f, 3.7f, 4.7f } } }, { { { 5.7f, 6.7f, 7.7f, 8.7f } } }, { { { 9.7f, 10.7f, 11.7f, 12.7f } } }, { { { 13.7f, 14.7f, 15.7f, 16.7f } } }
     };
 
-    ScopedAlignedArrayXVEC unity(reinterpret_cast<XVEC*>(_aligned_malloc(sizeof(XVEC) * 32, 16)));
+    ScopedAlignedArrayXVEC unity(reinterpret_cast<XVEC*>(XM_ALIGNED_MALLOC(sizeof(XVEC) * 32, 16)));
     FFTInitializeUnityTable(reinterpret_cast<XMVECTOR*>(unity.get()), 32);
 
     FFTInterleaved(reinterpret_cast<XMVECTOR*>(rinput), reinterpret_cast<XMVECTOR*>(iinput), reinterpret_cast<XMVECTOR*>(unity.get()), 2, 5 );
@@ -432,7 +440,7 @@ bool IFFTDeinterleavedTest()
                       { { { 1.6f, 2.6f, 3.6f, 4.6f } } }, { { { 5.6f, 6.6f, 7.6f, 8.6f } } }, { { { 9.6f, 10.6f, 11.6f, 12.6f } } }, { { { 13.6f, 14.6f, 15.6f, 16.6f } } },
                       { { { 1.7f, 2.7f, 3.7f, 4.7f } } }, { { { 5.7f, 6.7f, 7.7f, 8.7f } } }, { { { 9.7f, 10.7f, 11.7f, 12.7f } } }, { { { 13.7f, 14.7f, 15.7f, 16.7f } } } };
        
-    ScopedAlignedArrayXVEC unity(reinterpret_cast<XVEC*>(_aligned_malloc(sizeof(XVEC) * 32, 16)));
+    ScopedAlignedArrayXVEC unity(reinterpret_cast<XVEC*>(XM_ALIGNED_MALLOC(sizeof(XVEC) * 32, 16)));
     FFTInitializeUnityTable(reinterpret_cast<XMVECTOR*>(unity.get()), 32);
 
     IFFTDeinterleaved(reinterpret_cast<XMVECTOR*>(rinput), reinterpret_cast<XMVECTOR*>(iinput), reinterpret_cast<XMVECTOR*>(unity.get()), 2, 5 );


### PR DESCRIPTION
* `cmake`: refactor and add GCC support
* `cpuid`: removed unneeded includes, fix cpuid call for GCC
* `ext`: removed `windows.h` include
* `math3`: fix include filenames casing
* `math3`: added lacking defines for non-Windows platforms
* `math3`: replace `rand()` with `XM_RAND()` which max values is limited with `0x8000` (glibc version generates values up to INT32_MAX, which causes test failures with GCC)
* `math3`, `shmath`: replace functions like `_fpclass` with `std::` alternatives
* `xdsp`: replace `_aligned_malloc` with `XM_ALIGNED_MALLOC`, which selects `_aligned_malloc` on MSVC and `std::aligned_alloc` on other toolsets

Requires https://github.com/microsoft/DirectXMath/pull/86


-----

Tested with
* Ubuntu 20.04
   - GCC 9
   - Clang 9
* Windows
  - MSVS 16.4.5
  - Clang-CL 9.0.0
