### PR TITLE
Update tests for BUILD_XSDP and BUILD_SHMATH CMake opts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,11 @@ if(NOT EXISTS "${DIRECTXMATH_PATH}/Inc/DirectXMath.h")
   message(FATAL_ERROR "DirectXMath test suite should be located 'below' DirectXMath")
 endif()
 
-link_libraries(DirectXMath)
+if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
+    include_directories(${DIRECTXMATH_PATH}/Inc)
+else()
+    link_libraries(DirectXMath)
+endif()
 
 if(DEFINED VCPKG_TARGET_ARCHITECTURE)
     set(DXMATH_ARCHITECTURE ${VCPKG_TARGET_ARCHITECTURE})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ if(NOT EXISTS "${DIRECTXMATH_PATH}/Inc/DirectXMath.h")
   message(FATAL_ERROR "DirectXMath test suite should be located 'below' DirectXMath")
 endif()
 
-include_directories(${DIRECTXMATH_PATH}/Inc)
+link_libraries(DirectXMath)
 
 if(DEFINED VCPKG_TARGET_ARCHITECTURE)
     set(DXMATH_ARCHITECTURE ${VCPKG_TARGET_ARCHITECTURE})
@@ -198,8 +198,10 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
     endif()
 endif()
 
-# Always use retail static CRT for this tool
-set(CMAKE_MSVC_RUNTIME_LIBRARY MultiThreaded)
+if(NOT BUILD_SHMATH)
+    # Always use retail static CRT for this tool
+    set(CMAKE_MSVC_RUNTIME_LIBRARY MultiThreaded)
+endif()
 
 enable_testing()
 
@@ -240,10 +242,15 @@ add_executable(shmathtest
     ${DIRECTXMATH_PATH}/SHMath/DirectXSH.cpp
     ${DIRECTXMATH_PATH}/SHMath/DirectXSH.h)
 target_compile_options(shmathtest PRIVATE ${ARCH_SSE2})
-target_include_directories( shmathtest PUBLIC ${DIRECTXMATH_PATH}/SHMath )
 source_group(shmathtest REGULAR_EXPRESSION shmath/*.*)
 add_test(NAME "shmath" COMMAND shmathtest WORKING_DIRECTORY $<TARGET_FILE_DIR:shmathtest>)
 set_tests_properties(shmath PROPERTIES LABELS "Library;SH")
+
+if(BUILD_SHMATH)
+    target_link_libraries(shmathtest PRIVATE DirectXSH)
+else()
+    target_include_directories( shmathtest PUBLIC ${DIRECTXMATH_PATH}/SHMath )
+endif()
 
 add_custom_command(
   TARGET shmathtest POST_BUILD
@@ -254,10 +261,15 @@ add_custom_command(
 
 add_executable(xdsptest xdsp/Test.cpp)
 target_compile_options(xdsptest PRIVATE ${ARCH_SSE2})
-target_include_directories( xdsptest PUBLIC ${DIRECTXMATH_PATH}/XDSP )
-source_group(XDSPTest REGULAR_EXPRESSION xdsp/*.*)
+source_group(xdsptest REGULAR_EXPRESSION xdsp/*.*)
 add_test(NAME "xdsp" COMMAND xdsptest)
 set_tests_properties(xdsp PROPERTIES LABELS "Library;XDSP")
+
+if(BUILD_XDSP)
+    target_link_libraries(xdsptest PRIVATE XDSP)
+else()
+    target_include_directories(xdsptest PUBLIC ${DIRECTXMATH_PATH}/XDSP )
+endif()
 
 set(DXMATH_TESTS headertest math3 stacktest shmathtest xdsptest)
 
@@ -358,19 +370,25 @@ if(WIN32 AND NOT MINGW)
         target_compile_options(math3_avx PRIVATE ${ARCH_AVX})
     endif()
 
-    target_sources(shmathtest PRIVATE
+    set(SHMATH_DX11_SOURCES
         shmath/DDSTextureLoader11.cpp
-        shmath/DDSTextureLoader11.h
-        ${DIRECTXMATH_PATH}/SHMath/DirectXSHD3D11.cpp)
+        shmath/DDSTextureLoader11.h)
+    if(NOT (BUILD_SHMATH AND BUILD_DX11))
+        set(SHMATH_DX11_SOURCES ${SHMATH_DX11_SOURCES} ${DIRECTXMATH_PATH}/SHMath/DirectXSHD3D11.cpp)
+    endif()
+    target_sources(shmathtest PRIVATE ${SHMATH_DX11_SOURCES})
     target_compile_definitions(shmathtest PRIVATE USE_DIRECT3D11=1)
-    target_link_libraries(shmathtest d3d11.lib dxgi.lib dxguid.lib)
+    target_link_libraries(shmathtest PRIVATE d3d11.lib dxgi.lib dxguid.lib)
 
-    target_sources(shmathtest PRIVATE
+    set(SHMATH_DX11_SOURCES
         shmath/DDSTextureLoader12.cpp
-        shmath/DDSTextureLoader12.h
-        ${DIRECTXMATH_PATH}/SHMath/DirectXSHD3D12.cpp)
+        shmath/DDSTextureLoader12.h)
+        if(NOT (BUILD_SHMATH AND BUILD))
+        set(SHMATH_DX11_SOURCES ${SHMATH_DX11_SOURCES} ${DIRECTXMATH_PATH}/SHMath/DirectXSHD3D12.cpp)
+    endif()
+    target_sources(shmathtest PRIVATE ${SHMATH_DX11_SOURCES})
     target_compile_definitions(shmathtest PRIVATE USE_DIRECT3D12=1)
-    target_link_libraries(shmathtest d3d12.lib)
+    target_link_libraries(shmathtest PRIVATE d3d12.lib)
 endif()
 
 message(STATUS "Enabled tests: ${DXMATH_TESTS}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -380,13 +380,13 @@ if(WIN32 AND NOT MINGW)
     target_compile_definitions(shmathtest PRIVATE USE_DIRECT3D11=1)
     target_link_libraries(shmathtest PRIVATE d3d11.lib dxgi.lib dxguid.lib)
 
-    set(SHMATH_DX11_SOURCES
+    set(SHMATH_DX12_SOURCES
         shmath/DDSTextureLoader12.cpp
         shmath/DDSTextureLoader12.h)
-        if(NOT (BUILD_SHMATH AND BUILD))
-        set(SHMATH_DX11_SOURCES ${SHMATH_DX11_SOURCES} ${DIRECTXMATH_PATH}/SHMath/DirectXSHD3D12.cpp)
+        if(NOT (BUILD_SHMATH AND BUILD_DX12))
+        set(SHMATH_DX12_SOURCES ${SHMATH_DX12_SOURCES} ${DIRECTXMATH_PATH}/SHMath/DirectXSHD3D12.cpp)
     endif()
-    target_sources(shmathtest PRIVATE ${SHMATH_DX11_SOURCES})
+    target_sources(shmathtest PRIVATE ${SHMATH_DX12_SOURCES})
     target_compile_definitions(shmathtest PRIVATE USE_DIRECT3D12=1)
     target_link_libraries(shmathtest PRIVATE d3d12.lib)
 endif()

--- a/headertest/CMakeLists.txt
+++ b/headertest/CMakeLists.txt
@@ -39,7 +39,11 @@ elseif(CMAKE_VS_PLATFORM_NAME_DEFAULT MATCHES "^[Aa][Rr][Mm]64$")
 elseif(CMAKE_VS_PLATFORM_NAME_DEFAULT MATCHES "^[Aa][Rr][Mm]64EC$")
     set(DXMATH_ARCHITECTURE arm64ec)
 elseif(NOT (DEFINED DXMATH_ARCHITECTURE))
-    set(DXMATH_ARCHITECTURE "x64")
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "[Aa][Rr][Mm]64|aarch64|arm64")
+        set(DXMATH_ARCHITECTURE arm64)
+    else()
+        set(DXMATH_ARCHITECTURE x64)
+    endif()
 endif()
 
 if(NOT (DXMATH_ARCHITECTURE MATCHES "^arm"))
@@ -67,7 +71,7 @@ add_executable(${PROJECT_NAME}
     core.cpp
     packed.cpp)
 
-target_include_directories(${PROJECT_NAME} PRIVATE ${DIRECTXMATH_PATH}/Inc)
+target_link_libraries(${PROJECT_NAME} PRIVATE DirectXMath)
 
 target_compile_options(${PROJECT_NAME} PRIVATE ${ARCH_SSE2})
 

--- a/headertest/CMakeLists.txt
+++ b/headertest/CMakeLists.txt
@@ -71,7 +71,7 @@ add_executable(${PROJECT_NAME}
     core.cpp
     packed.cpp)
 
-target_link_libraries(${PROJECT_NAME} PRIVATE DirectXMath)
+include_directories(${DIRECTXMATH_PATH}/Inc)
 
 target_compile_options(${PROJECT_NAME} PRIVATE ${ARCH_SSE2})
 


### PR DESCRIPTION
The tests had been basically ignoring the CMake targets and doing direct include of SHMath and XDSP for testing.

* Change to use DirectXMath target instead of direct inclusion of `Inc` for all tests

* If building with `BUILD_XDSP` then use target instead of direct include

* If building with `BUILD_SHMATH` then use target instead of direct include. Also handle `BUILD_DX11` and `BUILD_DX12`.
