### PR TITLE
Enable /fp:fast fixes in all builds

### DIFF
--- a/math3/xmcolor.cpp
+++ b/math3/xmcolor.cpp
@@ -395,7 +395,7 @@ HRESULT Test057(LogProxy* pLog)
 HRESULT Test058(LogProxy* pLog)
 {
     //XMColorModulate
-#if defined(_M_FP_FAST) && defined(_XM_NO_INTRINSICS_)
+#if defined(_M_FP_FAST)
     // Under /fp:fast, it is possible for the compiler to optimize
     //  (a / 100.f) * (b / 100.f)
     // to

--- a/math3/xmvec.cpp
+++ b/math3/xmvec.cpp
@@ -1979,7 +1979,7 @@ HRESULT Test315(LogProxy* pLog)
     //XMVectorMultiply
     //XMVECTOR operator *=, *
     HRESULT ret = S_OK;
-#if defined(_M_FP_FAST) && defined(_XM_NO_INTRINSICS_)
+#if defined(_M_FP_FAST)
     // Under /fp:fast, it is possible for the compiler to optimize
     //  (a / 100.f) * (b / 100.f)
     // to


### PR DESCRIPTION
Recent changes in MSVC result in more aggressive optimization in `/fp:fast` mode. The rearrangement described by the comment now happens in all configurations. Adjust tests to avoid false failures.