### PR TITLE
CMake update for v4.1 change

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,7 +190,7 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "Intel")
     add_compile_options(/fp:fast /Zc:__cplusplus /Zc:inline /Qdiag-disable:177)
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
-    add_compile_options(/fp:fast /Zc:inline
+    add_compile_options(/fp:fast /Zc:forScope /Zc:inline /Zc:wchar_t
         /wd4061 /wd4365 /wd4514 /wd4710 /wd4820 /wd4668 /wd5039 /wd5045)
 
     if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.10)


### PR DESCRIPTION
In CMake 4.1, the VS Generator no longer adds `/Zc:forScope /Zc:inline /Zc:wchar_t` to compiler and `/DYNAMICBASE /NXCOMPAT /SAFESEH` to linker by default unless set in the CMake.

This adds them back to the project to ensure they are set in VS Generator scenarios. `/Zc:forScope /Zc:wchar_t` were already the compiler default, and the project already set the other ones so it shouldn't result in any real compilation change for existing CMake projects or the Ninja generator.
